### PR TITLE
ci: PR/dev/main 품질 게이트(lint + build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# 품질 게이트: PR과 dev/main push마다 lint + build 검증.
+# 배포(CD)는 Vercel이 담당하므로 여기서는 하지 않는다.
+on:
+  push:
+    branches: [dev, main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+
+# 같은 ref에서 새 커밋이 오면 진행 중인 CI는 취소 (배포가 아니므로 안전)
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## 요약
GitHub Actions로 **품질 게이트**를 추가합니다. 배포는 계속 Vercel(CD)이 담당하고, 여기서는 PR과 `dev`·`main` push마다 **lint + build**를 검증합니다.

## 내용
- `.github/workflows/ci.yml`: Node 22 + `npm ci`(캐시) → `next lint` → `next build`
- 트리거: `pull_request` + push `[dev, main]`, 문서 변경(`**/*.md`, `docs/**`)은 제외
- concurrency 가드로 같은 ref 중복 실행 취소

## 효과
- 로컬에서 config 로딩 실패로 못 돌리던 `next lint`를 **CI 클린 환경에서 실행** → 지난 footer 같은 lint 이슈를 Vercel 배포 이전에 검출
- 이후 Next.js 마이그레이션 PR들이 모두 자동 검증됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)