### PR TITLE
ci: dev → main 승격 PR 자동 생성

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,61 @@
+name: Promote
+
+# dev에 커밋이 올라올 때마다 dev → main(프로덕션) 승격 PR을 자동 생성/갱신한다.
+# 병합은 사람이 직접 한다(자동 병합하지 않음).
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: promote-dev-main
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    name: Open/refresh dev → main PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create or refresh dev → main PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # dev가 main보다 앞선 커밋이 없으면 승격할 것이 없음
+          ahead=$(git rev-list --count origin/main..origin/dev)
+          if [ "$ahead" -eq 0 ]; then
+            echo "dev is not ahead of main; nothing to promote."
+            exit 0
+          fi
+
+          # 승격 범위 커밋 목록으로 PR 본문 구성
+          body_file="$(mktemp)"
+          {
+            echo "\`dev\` → \`main\`(프로덕션) 승격 PR입니다. 이 PR을 병합하면 Vercel 프로덕션 배포가 진행됩니다."
+            echo ""
+            echo "**포함 커밋 (${ahead}):**"
+            git log --pretty=format:'- %s (%h)' origin/main..origin/dev
+            echo ""
+            echo ""
+            echo "> dev에 push될 때마다 이 PR이 자동 생성/갱신됩니다. 병합은 직접 진행하세요."
+          } > "$body_file"
+
+          existing="$(gh pr list --base main --head dev --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --title "[Deploy] dev → main" --body-file "$body_file"
+            echo "Refreshed existing PR #${existing}"
+          else
+            gh pr create --base main --head dev --title "[Deploy] dev → main" --body-file "$body_file"
+            echo "Created dev → main promotion PR"
+          fi


### PR DESCRIPTION
## 요약
`dev`에 커밋이 올라올 때마다 **`dev → main` 승격 PR을 자동 생성/갱신**하는 워크플로를 추가합니다. heurm의 `promote.yml`(int→main `[Deploy]`) 패턴을 포트폴리오의 2단계(dev→main)로 축약한 것입니다.

## 동작
- 트리거: `dev` push + 수동 `workflow_dispatch`
- 이미 열린 `dev→main` PR이 있으면 본문만 갱신, 없으면 새로 생성
- PR 본문에 **포함 커밋 목록** 자동 기재, `main`보다 앞선 커밋이 없으면 스킵
- **자동 병합하지 않음** — 병합은 직접 진행 (배포 승인 게이트 역할)

## ⚠️ 활성화 조건 (저장소 설정)
GitHub Actions가 PR을 생성하려면 저장소 설정이 필요합니다 (제가 못 바꾸는 부분):
**Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests" 체크**
(이미 켜져 있으면 추가 조치 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)