### PR TITLE
feat(home): 카드형 프로젝트 인덱스 리디자인

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,124 +1,64 @@
-import type React from "react"
 import Link from "next/link"
+import ProjectItem from "../../components/projects/projectItem"
+import AboutRail from "../../components/home/aboutRail"
+import { getProjects } from "../../lib/notion"
 
-const intro = [
-  "Java/Spring으로 개발을 시작해 금융권 이미지 솔루션 SI에서 C#/.NET으로 3년 이상 개발했습니다. 이후 병원 도메인 SaaS에 프론트엔드로 합류했다가 백엔드로 전환했습니다.",
-  "최근 2년 이상 멀티플랫폼 채팅/메시징 백엔드를 주도적으로 설계·소유하고 있으며, React 프론트엔드까지 직접 개발합니다. 성능·안정성 문제를 원리부터 이해해 정량적으로 풀어가는 것을 좋아합니다.",
-]
+export const revalidate = 3600
 
-const whatIDo = [
-  {
-    title: "실시간 채팅/메시징 백엔드 오너십",
-    body: "SignalR 이벤트 엔진 → WhatsApp·LINE·WeChat 통합 → 독립 플랫폼(Omni) 재구축. 프로덕션 8개 병원 테넌트 운영.",
-  },
-  {
-    title: "대용량 API 성능·안정성 개선",
-    body: "EF Core 쿼리 최적화, HTTP 복원력(Polly), 백그라운드 작업 영속화, Redis 세션 인프라로 장애에 강한 시스템 설계.",
-  },
-  {
-    title: "DDD · CQRS · 이벤트 기반 아키텍처",
-    body: ".NET 10, MassTransit + RabbitMQ 기반 이벤트 아키텍처와 멀티테넌시 도메인 설계.",
-  },
-]
+const HOME_CAP = 7
 
-const skills = [
-  { group: "Backend", items: "C#, ASP.NET Core, .NET 10, EF Core, SignalR, MassTransit, RabbitMQ, Hangfire, Polly" },
-  { group: "Database", items: "Azure SQL / MSSQL, Cosmos DB, Redis, Azure Cognitive Search" },
-  { group: "Architecture", items: "DDD, Clean Architecture, CQRS(MediatR), 이벤트 기반, 멀티테넌시" },
-  { group: "Cloud", items: "Azure Container Apps, .NET Aspire, GitHub Actions, Docker" },
-  { group: "Frontend", items: "React, TypeScript, Next.js, SWR" },
-]
+export default async function Home() {
+  const projects = await getProjects()
+  const homeProjects = projects.slice(0, HOME_CAP)
+  const hasMore = projects.length > homeProjects.length
 
-function Section({ n, title, children }: { n: string; title: string; children: React.ReactNode }) {
-  return (
-    <section className="border-t border-line py-10">
-      <h2 className="mb-5 text-xs font-bold uppercase tracking-[0.2em] text-muted">
-        <span className="mr-2 text-accent">{n}</span>
-        {title}
-      </h2>
-      {children}
-    </section>
-  )
-}
-
-export default function Home() {
   return (
     <>
-      {/* Hero */}
-      <section className="pb-6">
+      {/* Masthead */}
+      <section className="pb-8">
         <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">
           Backend Engineer · Fullstack
         </p>
-        <h1 className="mt-4 max-w-2xl text-3xl font-bold leading-[1.25] tracking-tight text-fg sm:text-[40px] sm:leading-[1.2]">
+        <h1 className="mt-4 max-w-2xl text-3xl font-bold leading-[1.2] tracking-tight text-fg sm:text-[40px]">
           헬스케어 SaaS의 채팅/메시징 백엔드를 설계·운영하는 C#/.NET 백엔드 개발자.
         </h1>
-        <div className="mt-7 flex flex-wrap gap-3">
-          <Link href="/projects" className="btn-accent">프로젝트 보기</Link>
-          <Link
-            href="/resume"
-            className="inline-flex items-center rounded-lg border border-line px-4 py-2 text-sm font-medium text-fg transition-colors hover:bg-surface"
-          >
-            정식 이력서 →
-          </Link>
-          <Link
-            href="/blog"
-            className="inline-flex items-center rounded-lg border border-line px-4 py-2 text-sm font-medium text-fg transition-colors hover:bg-surface"
-          >
-            블로그
-          </Link>
-        </div>
+        <p className="mt-5 font-mono text-xs tracking-widest text-muted">
+          {`${projects.length}개 프로젝트 · 2019—NOW`}
+        </p>
       </section>
 
-      <Section n="01" title="About">
-        <div className="space-y-4 text-[15px] leading-relaxed text-muted">
-          {intro.map((p, i) => (
-            <p key={i}>{p}</p>
-          ))}
-        </div>
-      </Section>
+      <div className="border-t border-line" />
 
-      <Section n="02" title="What I do">
-        <div className="grid gap-4 sm:grid-cols-2">
-          {whatIDo.map((w) => (
-            <div key={w.title} className="border-l-2 border-accent/40 pl-4">
-              <h3 className="text-[15px] font-semibold text-fg">{w.title}</h3>
-              <p className="mt-1.5 text-sm leading-relaxed text-muted">{w.body}</p>
-            </div>
-          ))}
-        </div>
-      </Section>
-
-      <Section n="03" title="Stack">
-        <dl className="divide-y divide-line">
-          {skills.map((s) => (
-            <div key={s.group} className="grid grid-cols-1 gap-1 py-3 sm:grid-cols-[110px_1fr]">
-              <dt className="font-mono text-xs text-accent">{s.group}</dt>
-              <dd className="text-sm text-muted">{s.items}</dd>
-            </div>
-          ))}
-        </dl>
-      </Section>
-
-      <Section n="04" title="Featured">
-        <Link href="/projects" className="group block">
-          <div className="flex items-baseline justify-between gap-4">
-            <h3 className="text-xl font-bold text-fg group-hover:text-accent">
-              멀티플랫폼 채팅/메시징 백엔드
-            </h3>
-            <span className="whitespace-nowrap font-mono text-xs text-muted">2024.09 – 현재</span>
+      {/* 2-column split: project index + colophon rail */}
+      <div className="mt-8 lg:grid lg:grid-cols-[minmax(0,1fr)_260px] lg:gap-12">
+        {/* LEFT: project index */}
+        <div className="lg:order-first">
+          <div className="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2">
+            {homeProjects.map((p, i) =>
+              i === 0 ? (
+                <div key={p.id} className="sm:col-span-2">
+                  <ProjectItem data={p} />
+                </div>
+              ) : (
+                <ProjectItem key={p.id} data={p} />
+              )
+            )}
           </div>
-          <p className="mt-3 text-sm leading-relaxed text-muted">
-            실시간 상담 채팅을 SignalR 이벤트 엔진에서 시작해 WhatsApp·LINE·WeChat 통합을 거쳐
-            독립 플랫폼(Omni)으로 재구축한 2.5년 백엔드 오너십.
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {[".NET 10", "SignalR", "MassTransit", "Cosmos DB", "Redis"].map((t) => (
-              <span key={t} className="chip">{t}</span>
-            ))}
-          </div>
-          <span className="mt-5 inline-block text-sm text-accent">프로젝트 전체 보기 →</span>
-        </Link>
-      </Section>
+
+          {hasMore && (
+            <div className="mt-4">
+              <Link href="/projects" className="link-underline text-sm">
+                전체 보기 →
+              </Link>
+            </div>
+          )}
+        </div>
+
+        {/* RIGHT: colophon rail (above index on mobile) */}
+        <div className="mb-10 order-first lg:order-last lg:mb-0">
+          <AboutRail />
+        </div>
+      </div>
     </>
   )
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -19,10 +19,7 @@ export default async function Home() {
         <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">
           Backend Engineer · Fullstack
         </p>
-        <h1 className="mt-4 max-w-2xl text-3xl font-bold leading-[1.2] tracking-tight text-fg sm:text-[40px]">
-          헬스케어 SaaS의 채팅/메시징 백엔드를 설계·운영하는 C#/.NET 백엔드 개발자.
-        </h1>
-        <p className="mt-5 font-mono text-xs tracking-widest text-muted">
+        <p className="mt-3 font-mono text-xs tracking-widest text-muted">
           {`${projects.length}개 프로젝트 · 2019—NOW`}
         </p>
       </section>

--- a/app/(site)/projects/page.tsx
+++ b/app/(site)/projects/page.tsx
@@ -1,84 +1,8 @@
-import ProjectItem, { type Project } from "../../../components/projects/projectItem"
-import { TOKEN, DATABASE_ID } from "../../../config/index"
+import ProjectItem from "../../../components/projects/projectItem"
+import { getProjects } from "../../../lib/notion"
 
 export const metadata = { title: "Projects" }
 export const revalidate = 3600
-
-// Notion query 응답 중 실제로 사용하는 필드만 최소한으로 정의
-interface NotionText {
-  plain_text?: string
-}
-interface NotionSelectOption {
-  id: string
-  name: string
-}
-interface NotionProperties {
-  projectName?: { title?: NotionText[] }
-  description?: { rich_text?: NotionText[] }
-  tag?: { multi_select?: NotionSelectOption[] }
-  github?: { url?: string }
-  workPeriod?: { date?: { start?: string; end?: string } }
-  status?: { status?: { name?: string } }
-}
-interface NotionPage {
-  id: string
-  properties?: NotionProperties
-  cover?: { external?: { url?: string }; file?: { url?: string } }
-}
-interface NotionQueryResponse {
-  results?: NotionPage[]
-}
-
-async function getProjects(): Promise<Project[]> {
-  // 토큰/DB가 없거나 요청이 실패해도 빌드가 깨지지 않도록 방어적으로 처리
-  if (!TOKEN || !DATABASE_ID) {
-    return []
-  }
-
-  const options = {
-    method: "POST",
-    headers: {
-      accept: "application/json",
-      "Notion-Version": "2022-06-28",
-      "content-type": "application/json",
-      Authorization: `Bearer ${TOKEN}`,
-    },
-    body: JSON.stringify({
-      sorts: [{ property: "projectName", direction: "ascending" }],
-      page_size: 100,
-    }),
-    next: { revalidate: 3600 },
-  }
-
-  try {
-    const res = await fetch(
-      `https://api.notion.com/v1/databases/${DATABASE_ID}/query`,
-      options
-    )
-    if (!res.ok) throw new Error(`Notion API ${res.status}`)
-    const projects = (await res.json()) as NotionQueryResponse
-
-    const ProjectArr: Project[] = (projects.results || []).map((data) => {
-      const p = data.properties || {}
-      return {
-        id: data.id,
-        projectName: p.projectName?.title?.[0]?.plain_text ?? "",
-        description: p.description?.rich_text?.[0]?.plain_text ?? "",
-        cover: data.cover?.external?.url || data.cover?.file?.url || "",
-        tags: p.tag?.multi_select ?? [],
-        url: p.github?.url || "",
-        startDate: p.workPeriod?.date?.start || "",
-        endDate: p.workPeriod?.date?.end || "",
-        status: p.status?.status?.name === "Done",
-      }
-    })
-
-    return ProjectArr
-  } catch (e) {
-    console.error("[projects] Notion fetch failed:", (e as Error).message)
-    return []
-  }
-}
 
 export default async function Projects() {
   const ProjectArr = await getProjects()

--- a/components/home/aboutRail.tsx
+++ b/components/home/aboutRail.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link"
+import { intro } from "./homeData"
+
+const stack = ["C#", ".NET 10", "EF Core", "SignalR", "MassTransit", "Redis"]
+
+export default function AboutRail() {
+  return (
+    <aside className="lg:sticky lg:top-14 lg:self-start lg:border-l lg:border-line lg:pl-8">
+      {/* Identity */}
+      <p className="text-base font-bold text-fg">오세준 (Sejune Oh)</p>
+      <p className="mt-1 font-mono text-xs uppercase tracking-[0.2em] text-accent">
+        BACKEND · C#/.NET
+      </p>
+
+      {/* Intro */}
+      <p className="mt-3 text-[13px] leading-relaxed text-muted">{intro[0]}</p>
+
+      <hr className="my-5 border-t border-line" />
+
+      {/* Stack */}
+      <p className="font-mono text-xs uppercase tracking-[0.2em] text-muted">Stack</p>
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {stack.map((s) => (
+          <span key={s} className="chip">
+            {s}
+          </span>
+        ))}
+      </div>
+
+      <hr className="my-5 border-t border-line" />
+
+      {/* Now */}
+      <p className="flex items-center gap-1.5 font-mono text-xs uppercase tracking-[0.2em] text-muted">
+        <span aria-hidden className="text-accent">●</span>
+        Now
+      </p>
+      <p className="mt-3 text-[13px] font-medium text-fg">멀티플랫폼 채팅/메시징 백엔드 (Omni)</p>
+      <p className="mt-1 font-mono text-[11px] text-muted">2024.09 — 현재 · 진행 중</p>
+      <Link href="/projects" className="link-underline mt-4 inline-block text-[13px]">
+        전체 프로젝트 →
+      </Link>
+    </aside>
+  )
+}

--- a/components/home/homeData.ts
+++ b/components/home/homeData.ts
@@ -1,0 +1,39 @@
+// 홈 페이지에서 사용하는 정적 콘텐츠 (intro / whatIDo / skills)
+
+export const intro: string[] = [
+  "Java/Spring으로 개발을 시작해 금융권 이미지 솔루션 SI에서 C#/.NET으로 3년 이상 개발했습니다. 이후 병원 도메인 SaaS에 프론트엔드로 합류했다가 백엔드로 전환했습니다.",
+  "최근 2년 이상 멀티플랫폼 채팅/메시징 백엔드를 주도적으로 설계·소유하고 있으며, React 프론트엔드까지 직접 개발합니다. 성능·안정성 문제를 원리부터 이해해 정량적으로 풀어가는 것을 좋아합니다.",
+]
+
+export interface WhatIDoItem {
+  title: string
+  body: string
+}
+
+export const whatIDo: WhatIDoItem[] = [
+  {
+    title: "실시간 채팅/메시징 백엔드 오너십",
+    body: "SignalR 이벤트 엔진 → WhatsApp·LINE·WeChat 통합 → 독립 플랫폼(Omni) 재구축. 프로덕션 8개 병원 테넌트 운영.",
+  },
+  {
+    title: "대용량 API 성능·안정성 개선",
+    body: "EF Core 쿼리 최적화, HTTP 복원력(Polly), 백그라운드 작업 영속화, Redis 세션 인프라로 장애에 강한 시스템 설계.",
+  },
+  {
+    title: "DDD · CQRS · 이벤트 기반 아키텍처",
+    body: ".NET 10, MassTransit + RabbitMQ 기반 이벤트 아키텍처와 멀티테넌시 도메인 설계.",
+  },
+]
+
+export interface SkillGroup {
+  group: string
+  items: string
+}
+
+export const skills: SkillGroup[] = [
+  { group: "Backend", items: "C#, ASP.NET Core, .NET 10, EF Core, SignalR, MassTransit, RabbitMQ, Hangfire, Polly" },
+  { group: "Database", items: "Azure SQL / MSSQL, Cosmos DB, Redis, Azure Cognitive Search" },
+  { group: "Architecture", items: "DDD, Clean Architecture, CQRS(MediatR), 이벤트 기반, 멀티테넌시" },
+  { group: "Cloud", items: "Azure Container Apps, .NET Aspire, GitHub Actions, Docker" },
+  { group: "Frontend", items: "React, TypeScript, Next.js, SWR" },
+]

--- a/components/projects/projectItem.tsx
+++ b/components/projects/projectItem.tsx
@@ -1,4 +1,4 @@
-import Badge from "../badge";
+import Link from "next/link"
 
 export interface ProjectTag {
   id: string;
@@ -17,58 +17,109 @@ export interface Project {
   status: boolean;
 }
 
-export default function ProjectItem({ data }: { data: Project }) {
-  const period = data.status
-    ? `${data.startDate} ~ ${data.endDate}`
-    : `${data.startDate} ~ 진행 중`;
+const cardClass =
+  "card group flex h-full flex-col overflow-hidden break-inside-avoid mb-8 " +
+  "hover:border-accent/60 hover:bg-surface-hover motion-safe:hover:-translate-y-0.5 " +
+  "focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30";
 
-  return (
-    <div className="mb-8 break-inside-avoid">
-      <article className="group">
-        {data.cover && (
-          <div className="overflow-hidden">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={data.cover}
-              alt={data.projectName}
-              loading="lazy"
-              className="h-auto w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
-            />
+export default function ProjectItem({ data }: { data: Project }) {
+  const glyph = Array.from(data.projectName)[0] ?? "·";
+  const firstTag = data.tags?.[0]?.name;
+  // status: true = Done, false = 진행 중
+  const inProgress = !data.status;
+  // 프로젝트명 기반 결정적 각도(해치 텍스처가 카드마다 조금씩 달라지도록)
+  const hatchAngle =
+    (Array.from(data.projectName).reduce((sum, ch) => sum + ch.charCodeAt(0), 0) % 4) * 45;
+
+  const hasPeriod = Boolean(data.startDate);
+  const period = `${data.startDate} — ${data.endDate || "현재"}`;
+
+  const body = (
+    <>
+      {/* Cover strip */}
+      <div className="aspect-[16/9] w-full overflow-hidden">
+        {data.cover ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={data.cover}
+            alt=""
+            loading="lazy"
+            className="h-full w-full object-cover grayscale-[15%] opacity-95 transition group-hover:grayscale-0 group-hover:opacity-100 motion-safe:group-hover:scale-[1.03]"
+          />
+        ) : (
+          <div
+            className="relative flex h-full w-full items-center justify-center bg-page"
+            style={{
+              backgroundImage: `repeating-linear-gradient(${hatchAngle}deg, var(--border) 0 1px, transparent 1px 8px)`,
+            }}
+          >
+            <span className="font-mono text-4xl font-extrabold text-muted/40">{glyph}</span>
+            {firstTag && (
+              <span className="absolute right-3 top-2 font-mono text-[10px] uppercase tracking-widest text-muted">
+                {firstTag}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 flex-col p-5">
+        <h3 className="flex items-center gap-1.5 text-[15px] font-bold text-fg group-hover:text-accent">
+          <span
+            aria-hidden
+            className={`text-xs ${inProgress ? "text-accent" : "text-muted"}`}
+          >
+            {inProgress ? "●" : "○"}
+          </span>
+          <span className="line-clamp-1">{data.projectName}</span>
+        </h3>
+
+        {data.description && (
+          <p className="mt-1.5 text-sm leading-relaxed text-muted line-clamp-2">
+            {data.description}
+          </p>
+        )}
+
+        {data.tags?.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {data.tags.slice(0, 3).map((tag) => (
+              <span key={tag.id} className="chip">
+                {tag.name}
+              </span>
+            ))}
+            {data.tags.length > 3 && (
+              <span className="chip">+{data.tags.length - 3}</span>
+            )}
           </div>
         )}
 
-        <div className="pt-3">
-          <h3 className="flex items-center gap-2 text-base font-bold text-fg transition-colors group-hover:text-accent">
-            {data.projectName}
-            {data.status && <span className="chip">Done</span>}
-          </h3>
-
-          {data.description && (
-            <p className="mt-1.5 text-sm leading-relaxed text-muted">{data.description}</p>
-          )}
-
-          <p className="mt-2 font-mono text-xs text-muted">{period}</p>
-
-          {data.tags?.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {data.tags.map((tag) => (
-                <Badge key={tag.id} text={tag.name} />
-              ))}
-            </div>
-          )}
-
+        <div className="mt-auto flex items-center justify-between border-t border-line pt-4">
+          <span className="font-mono text-xs text-muted">{hasPeriod ? period : ""}</span>
           {data.url && (
-            <a
-              href={data.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-block text-sm text-accent transition-colors hover:text-accent-hover"
-            >
+            <span className="text-sm text-accent group-hover:text-accent-hover">
               GitHub →
-            </a>
+            </span>
           )}
         </div>
-      </article>
-    </div>
+      </div>
+    </>
+  );
+
+  // 카드 전체를 하나의 링크로: url 있으면 외부 GitHub, 없으면 /projects 로.
+  // 앵커 중첩을 피하기 위해 내부에는 별도의 <a>/<Link> 를 두지 않는다.
+  return data.url ? (
+    <a
+      href={data.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cardClass}
+    >
+      {body}
+    </a>
+  ) : (
+    <Link href="/projects" className={cardClass}>
+      {body}
+    </Link>
   );
 }

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,0 +1,84 @@
+import type { Project } from "../components/projects/projectItem"
+import { TOKEN, DATABASE_ID } from "../config"
+import { fallbackProjects } from "./projectsFallback"
+
+// Notion query 응답 중 실제로 사용하는 필드만 최소한으로 정의
+interface NotionText {
+  plain_text?: string
+}
+interface NotionSelectOption {
+  id: string
+  name: string
+}
+interface NotionProperties {
+  projectName?: { title?: NotionText[] }
+  description?: { rich_text?: NotionText[] }
+  tag?: { multi_select?: NotionSelectOption[] }
+  github?: { url?: string }
+  workPeriod?: { date?: { start?: string; end?: string } }
+  status?: { status?: { name?: string } }
+}
+interface NotionPage {
+  id: string
+  properties?: NotionProperties
+  cover?: { external?: { url?: string }; file?: { url?: string } }
+}
+interface NotionQueryResponse {
+  results?: NotionPage[]
+}
+
+export async function getProjects(): Promise<Project[]> {
+  // 토큰/DB가 없거나 요청이 실패해도 빌드가 깨지지 않도록 방어적으로 처리
+  if (!TOKEN || !DATABASE_ID) {
+    return fallbackProjects
+  }
+
+  const options = {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "Notion-Version": "2022-06-28",
+      "content-type": "application/json",
+      Authorization: `Bearer ${TOKEN}`,
+    },
+    body: JSON.stringify({
+      sorts: [{ property: "projectName", direction: "ascending" }],
+      page_size: 100,
+    }),
+    next: { revalidate: 3600 },
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.notion.com/v1/databases/${DATABASE_ID}/query`,
+      options
+    )
+    if (!res.ok) throw new Error(`Notion API ${res.status}`)
+    const projects = (await res.json()) as NotionQueryResponse
+
+    const ProjectArr: Project[] = (projects.results || []).map((data) => {
+      const p = data.properties || {}
+      return {
+        id: data.id,
+        projectName: p.projectName?.title?.[0]?.plain_text ?? "",
+        description: p.description?.rich_text?.[0]?.plain_text ?? "",
+        cover: data.cover?.external?.url || data.cover?.file?.url || "",
+        tags: p.tag?.multi_select ?? [],
+        url: p.github?.url || "",
+        startDate: p.workPeriod?.date?.start || "",
+        endDate: p.workPeriod?.date?.end || "",
+        status: p.status?.status?.name === "Done",
+      }
+    })
+
+    // 결과가 비어 있으면 큐레이션된 대체 목록으로 폴백
+    if (ProjectArr.length === 0) {
+      return fallbackProjects
+    }
+
+    return ProjectArr
+  } catch (e) {
+    console.error("[projects] Notion fetch failed:", (e as Error).message)
+    return fallbackProjects
+  }
+}

--- a/lib/projectsFallback.ts
+++ b/lib/projectsFallback.ts
@@ -1,0 +1,89 @@
+import type { Project } from "../components/projects/projectItem"
+
+// Notion 연동이 비어 있을 때 사용하는 큐레이션된 대체 프로젝트 목록.
+// site/resume에 이미 존재하는 사실만 사용하고, 새로운 지표는 만들지 않는다.
+export const fallbackProjects: Project[] = [
+  {
+    id: "omni-messaging-backend",
+    projectName: "멀티플랫폼 채팅/메시징 백엔드 (Omni)",
+    description:
+      "SignalR 이벤트 엔진에서 시작해 WhatsApp·LINE·WeChat 통합을 거쳐 독립 플랫폼(Omni)으로 재구축한 백엔드 오너십.",
+    cover: "",
+    tags: [
+      { id: "dotnet", name: ".NET 10" },
+      { id: "signalr", name: "SignalR" },
+      { id: "masstransit", name: "MassTransit" },
+      { id: "cosmos", name: "Cosmos DB" },
+      { id: "redis", name: "Redis" },
+    ],
+    url: "",
+    startDate: "2024.09",
+    endDate: "",
+    status: false,
+  },
+  {
+    id: "ef-core-query-optimization",
+    projectName: "EF Core 쿼리 최적화",
+    description:
+      "ProjectTo 위에 남아 있던 Include가 만든 카테시안 폭발을 AsSplitQuery로 잡아 91초 걸리던 API를 0.04초로 개선.",
+    cover: "",
+    tags: [
+      { id: "efcore", name: "EF Core" },
+      { id: "csharp", name: "C#" },
+      { id: "performance", name: "Performance" },
+    ],
+    url: "",
+    startDate: "2026.05",
+    endDate: "2026.07",
+    status: true,
+  },
+  {
+    id: "polly-http-resilience",
+    projectName: "HTTP 복원력 계층 (Polly)",
+    description:
+      "전이성 네트워크·5xx 실패로 쌓인 자동 리포트를 지수 백오프 재시도와 토큰 캐싱으로 구조적으로 줄인 복원력 계층.",
+    cover: "",
+    tags: [
+      { id: "polly", name: "Polly" },
+      { id: "dotnet-res", name: ".NET" },
+      { id: "resilience", name: "Resilience" },
+    ],
+    url: "",
+    startDate: "2026.06",
+    endDate: "2026.06",
+    status: true,
+  },
+  {
+    id: "sms-ciba-authentication",
+    projectName: "SMS CIBA 인증",
+    description:
+      "SMS 기반 CIBA(Client-Initiated Backchannel Authentication) 인증 흐름을 백엔드에 통합한 작업.",
+    cover: "",
+    tags: [
+      { id: "ciba", name: "CIBA" },
+      { id: "auth", name: "Auth" },
+      { id: "sms", name: "SMS" },
+    ],
+    url: "",
+    startDate: "2025.01",
+    endDate: "2025.03",
+    status: true,
+  },
+  {
+    id: "ehrapi-event-driven-backend",
+    projectName: "EhrApi 이벤트 기반 백엔드",
+    description:
+      "MassTransit + RabbitMQ 기반 이벤트 아키텍처와 멀티테넌시 도메인 설계를 적용한 병원 도메인 백엔드.",
+    cover: "",
+    tags: [
+      { id: "ddd", name: "DDD" },
+      { id: "cqrs", name: "CQRS" },
+      { id: "rabbitmq", name: "RabbitMQ" },
+      { id: "multitenancy", name: "멀티테넌시" },
+    ],
+    url: "",
+    startDate: "2022.01",
+    endDate: "2024.08",
+    status: true,
+  },
+]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
+    "./app/**/*.{js,ts,jsx,tsx}",
   ],
   darkMode: "class",
   theme: {


### PR DESCRIPTION
## 요약
홈을 매거진형 레이아웃으로 재설계합니다 (imweb 레퍼런스 참고, planner·designer 에이전트 협의 반영).

Closes #22

## 레이아웃 (사이드바 유지 · main 내 2열)
- **좌**: 프로젝트 카드 그리드 — 첫 카드 Featured 2열 span, 나머지 균일 2열. 홈은 최대 7개 + `전체 보기 →`
- **우**: 소개 콜로폰 rail — 신원·1줄 소개·STACK 칩·`NOW ●` (내비/연락처는 사이드바에 있으니 중복 없음), 데스크톱 sticky

## 카드 디자인
- flat(그림자 없음) + hairline 보더, hover 시 accent 보더/surface-hover/살짝 상승
- **커버 없으면 모노그램 플레이트**(해치 텍스처 + 첫 글자) → 백엔드 텍스트 카드도 의도적으로
- 상태 dot, 칩 최대 3개 + `+N`, 기간 mono, focus-visible 링, `motion-safe:` hover

## 데이터
- projects Notion 페치를 `lib/notion.ts`로 공유화(홈·/projects 공용)
- `lib/projectsFallback.ts`: env 없어도 홈이 비지 않도록 curated 5개(Omni 리드)

## 검증
- 로컬 `next build` 통과 (11 라우트, 홈 ISR 1h, 타입체크)
- CI(clean lint) + Vercel 프리뷰로 최종 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)