### PR TITLE
feat(auth): NextAuth + GitHub OAuth 로 /admin 보호 (PR-A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# ── NextAuth (Auth.js v5) ──────────────────────────────────────────
+# 세션 서명용 시크릿. 생성: `openssl rand -base64 32`
+AUTH_SECRET=
+
+# GitHub OAuth App (github.com/settings/developers → New OAuth App)
+#   - Homepage URL: 배포 도메인
+#   - Authorization callback URL:
+#       프로덕션: https://<도메인>/api/auth/callback/github
+#       로컬:     http://localhost:3000/api/auth/callback/github
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=
+
+# ── Notion (기존 프로젝트 연동 + 후속 PR) ───────────────────────────
+NOTION_TOKEN=
+NOTION_DB=
+# 후속 PR-B/PR-D 에서 사용
+# NOTION_BLOG_DB=
+# NOTION_INQUIRIES_DB=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next"
+import { auth, signOut } from "@/auth"
+
+// 검색엔진 비노출(민감 관리 페이지). 미들웨어가 접근 자체를 인증으로 막지만,
+// 색인/링크 노출도 이중으로 차단한다.
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+}
+
+// 세션 기반이라 정적 프리렌더 대상이 아님을 명시(빌드 시 실행 회피).
+export const dynamic = "force-dynamic"
+
+export default async function AdminPage() {
+  const session = await auth()
+  const name = session?.user?.name ?? "관리자"
+
+  return (
+    <main className="mx-auto max-w-[720px] px-6 py-16">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Admin</p>
+      <h1 className="mt-3 text-2xl font-semibold text-fg">콘텐츠 관리</h1>
+      <p className="mt-2 text-sm text-muted">
+        {name}님으로 로그인됨. 블로그·프로젝트·문의 관리는 다음 단계에서 추가됩니다.
+      </p>
+
+      {/* 후속 PR에서 채워질 자리 (PR-C: 쓰기 폼 / PR-D: 문의 목록) */}
+      <div className="mt-8 grid gap-3">
+        <div className="card p-5 text-sm text-muted">블로그 작성 · 목록 <span className="text-xs">(예정 — PR-C)</span></div>
+        <div className="card p-5 text-sm text-muted">프로젝트 등록 · 목록 <span className="text-xs">(예정 — PR-C)</span></div>
+        <div className="card p-5 text-sm text-muted">문의(이메일·면접 요청) 확인 <span className="text-xs">(예정 — PR-D)</span></div>
+      </div>
+
+      <form
+        action={async () => {
+          "use server"
+          await signOut({ redirectTo: "/" })
+        }}
+        className="mt-10"
+      >
+        <button type="submit" className="link-underline text-sm text-muted">
+          로그아웃 →
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth"
+
+export const { GET, POST } = handlers

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,26 @@
+import NextAuth from "next-auth"
+import GitHub from "next-auth/providers/github"
+
+// 이 사이트의 /admin 은 소유자 1인(GitHub: SejuneOh)만 접근한다.
+// GitHub OAuth 로 로그인하되, 아래 계정이 아니면 로그인을 거부한다.
+const ALLOWED_GITHUB_LOGIN = "SejuneOh"
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  // 세션은 DB 어댑터 없이 JWT 로 유지한다(엣지 미들웨어에서 세션 확인 가능).
+  session: { strategy: "jwt" },
+  providers: [GitHub],
+  callbacks: {
+    // GitHub 인증 성공 후, 허용된 계정만 통과시킨다.
+    signIn({ profile }) {
+      const login = (profile as { login?: string } | undefined)?.login
+      return login === ALLOWED_GITHUB_LOGIN
+    },
+    // 미들웨어에서 사용: /admin 이하는 인증된 사용자만, 그 외 경로는 통과.
+    authorized({ auth, request }) {
+      if (request.nextUrl.pathname.startsWith("/admin")) {
+        return !!auth?.user
+      }
+      return true
+    },
+  },
+})

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,8 @@
+// /admin/* 요청을 가로채 인증(authorized 콜백)을 강제한다.
+// 미인증 접근은 NextAuth 기본 로그인 페이지로 리다이렉트된다.
+export { auth as middleware } from "@/auth"
+
+export const config = {
+  // 정적 파일/이미지/공개 auth 엔드포인트는 제외하고 /admin 이하만 검사.
+  matcher: ["/admin/:path*"],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^15.5.20",
+        "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
@@ -39,6 +40,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -889,6 +919,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4128,6 +4167,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4477,6 +4525,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -4562,6 +4637,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -5058,6 +5142,25 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "next": "^15.5.20",
+    "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "paths": { "@/*": ["./*"] },
     "plugins": [{ "name": "next" }]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## 요약
콘텐츠 관리(블로그·프로젝트 Notion 업데이트, 문의 확인)의 기반이 되는 **인증된 `/admin` 진입점**을 추가한다. 이 PR은 인증 셸까지만 다루고, 실제 쓰기·문의 기능은 후속 PR에서 채운다.

Closes #25

## 변경
- **NextAuth(Auth.js v5) + GitHub OAuth**, JWT 세션 (`auth.ts`)
- `signIn` 콜백으로 허용 계정을 **소유자 1인(SejuneOh)** 으로 제한
- `middleware.ts` 로 `/admin/*` 인증 강제 — 미인증 접근은 로그인으로 리다이렉트
- `/admin` 빈 셸 페이지 + 서버 액션 로그아웃, `robots noindex`
- `tsconfig` 에 `@/*` 경로 별칭, `.eslintrc` `root:true`
- `.env.example` 로 필요한 환경변수 문서화

## 동작/안전성
- 토큰·시크릿은 **서버(미들웨어·라우트 핸들러)에서만** 사용, 클라이언트 번들 미포함
- **env 미설정 상태에서도 빌드/기존 페이지 정상 동작** (기능만 비활성) — 로컬 `next build` 11/11 정적 생성 통과 확인

## 병합 전 필요한 설정 (배포자)
1. GitHub OAuth App 생성 → `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET`
   - Callback: `https://<도메인>/api/auth/callback/github`, `http://localhost:3000/api/auth/callback/github`
2. `AUTH_SECRET` (`openssl rand -base64 32`)
3. 위 3개를 Vercel 환경변수 + 로컬 `.env.local` 에 등록

## 후속
- PR-B: 블로그 읽기 Notion 이관
- PR-C: `/admin` 쓰기 폼(블로그·프로젝트) → Notion
- PR-D: 공개 문의 폼 → Notion Inquiries DB + `/admin` 문의 목록