### PR TITLE
feat(blog): 블로그 콘텐츠 Notion DB 이관 — 읽기 (PR-B)

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 import type { Block as BlockType } from "../../../../lib/posts"
-import { posts, getPost, getAdjacent, readingMinutes } from "../../../../lib/posts"
+import { readingMinutes } from "../../../../lib/posts"
+import { getPosts, getPost, getAdjacent } from "../../../../lib/postsData"
 import CodeBlock from "../../../../components/blog/codeBlock"
 import Toc from "../../../../components/blog/toc"
 
@@ -36,7 +37,8 @@ function Block({ block, index }: { block: BlockType; index: number }) {
   return null
 }
 
-export function generateStaticParams() {
+export async function generateStaticParams() {
+  const posts = await getPosts()
   return posts.map((p) => ({ slug: p.slug }))
 }
 
@@ -46,7 +48,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>
 }): Promise<Metadata> {
   const { slug } = await params
-  const post = getPost(slug)
+  const post = await getPost(slug)
   if (!post) return {}
   return { title: post.title }
 }
@@ -57,10 +59,10 @@ export default async function Post({
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params
-  const post = getPost(slug)
+  const post = await getPost(slug)
   if (!post) notFound()
 
-  const { prev, next } = getAdjacent(slug)
+  const { prev, next } = await getAdjacent(slug)
   const toc = post.body
     .map((b, i) => (b.h ? { id: `h-${i}`, text: b.h } : null))
     .filter(Boolean) as TocItem[]

--- a/app/(site)/blog/page.tsx
+++ b/app/(site)/blog/page.tsx
@@ -1,7 +1,12 @@
 import BlogIndex from "../../../components/blogIndex"
+import { getPosts } from "../../../lib/postsData"
+import { deriveCategories } from "../../../lib/posts"
 
 export const metadata = { title: "Blog" }
+export const revalidate = 3600
 
-export default function Blog() {
-  return <BlogIndex />
+export default async function Blog() {
+  const posts = await getPosts()
+  const categories = deriveCategories(posts)
+  return <BlogIndex posts={posts} categories={categories} />
 }

--- a/components/blogIndex.tsx
+++ b/components/blogIndex.tsx
@@ -2,9 +2,15 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { posts, categories, readingMinutes } from "../lib/posts"
+import { readingMinutes, type Post } from "../lib/posts"
 
-export default function BlogIndex() {
+export default function BlogIndex({
+  posts,
+  categories,
+}: {
+  posts: Post[]
+  categories: string[]
+}) {
   const [active, setActive] = useState("All")
   const filtered = active === "All" ? posts : posts.filter((p) => p.category === active)
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,2 +1,5 @@
 export const DATABASE_ID = process.env.NOTION_DB
 export const TOKEN = process.env.NOTION_TOKEN
+
+// 블로그 콘텐츠용 Notion 데이터베이스 (PR-B: 읽기 / PR-C: 쓰기)
+export const BLOG_DATABASE_ID = process.env.NOTION_BLOG_DB

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,4 +1,6 @@
-// 블로그 콘텐츠 (추후 Notion DB 연동 가능 — projects.js 패턴 참고)
+// 블로그 도메인 타입 + 순수 유틸.
+// 이 모듈은 서버 전용 fetch 를 포함하지 않으므로 client 컴포넌트에서도 안전하게 import 가능하다.
+// 실제 데이터 조회(Notion)는 lib/postsData.ts, 시드 데이터는 lib/postsFallback.ts 참고.
 // body 블록: { p } 문단, { h } 소제목, { code } 코드, { ul } 목록
 
 export type Block =
@@ -13,104 +15,11 @@ export interface Post {
   date: string
   category: string
   tags: string[]
-  gradient: string
+  // 과거 카드 디자인용 그라디언트. 현재 렌더에는 미사용이라 선택값.
+  gradient?: string
   summary: string
   body: Block[]
 }
-
-export const categories: string[] = ["All", "Performance", "Backend", "Architecture"]
-
-export const posts: Post[] = [
-  {
-    slug: "ef-core-cartesian-explosion",
-    title: "EF Core 카테시안 폭발로 91초 걸리던 API를 0.04초로",
-    date: "2026-07-06",
-    category: "Performance",
-    tags: ["EF Core", "C#", "Performance"],
-    gradient: "from-[#2383e2] to-[#0b6bcb]",
-    summary:
-      "ProjectTo가 있는데도 남아 있던 Include가 만든 1.38억 row의 카테시안 폭발을 AsSplitQuery로 잡고, MD5로 응답 동일성까지 검증한 과정.",
-    body: [
-      { h: "증상: 1.38억 row의 카테시안 폭발" },
-      { p: "병원 목록 API에서 프로덕션 SQL 타임아웃이 반복됐다. 특정 상세 엔드포인트 하나가 전체 장애의 절반을 차지했고, 응답까지 91초가 걸렸다. AutoMapper ProjectTo로 필요한 컬럼만 투영하고 있어 무거울 이유가 없어 보였는데, 실제 생성 SQL은 전혀 달랐다." },
-      { p: "문제는 ProjectTo가 커버하는 프로젝션 위에 Include/ThenInclude 체인이 그대로 남아 있던 것. 여러 컬렉션을 한 쿼리로 조인하면서 행이 곱셈으로 폭발했다. COUNT_BIG으로 중간 물질화 행 수를 재보니 단일 쿼리가 약 1.38억 row를 만들고 있었다." },
-      { code: "-- 컬렉션 4개가 한 쿼리에서 곱해지며 중간 행 폭발\nSELECT ... FROM Hospitals h\n  LEFT JOIN Departments ...\n  LEFT JOIN Doctors ...\n  LEFT JOIN Translations ...   -- N x M x K x ...\n=> 138,523,392 rows materialized" },
-      { h: "해결: 불필요한 Include 제거 + 선택적 AsSplitQuery" },
-      { p: "프로젝션이 이미 커버하는 Include는 제거하고, 깊은 컬렉션을 다루는 핸들러에만 AsSplitQuery()를 적용해 하나의 카테시안 쿼리를 여러 개의 작은 쿼리로 분리했다. 곱셈이 덧셈으로 바뀌면서 중간 행 수가 수천 단위로 떨어졌다." },
-      { code: "var query = _db.Hospitals\n    .Where(predicate)\n    .AsSplitQuery()              // 곱집합 -> 분리 쿼리\n    .ProjectTo<HospitalDto>(_mapper.ConfigurationProvider);\n// Include/ThenInclude 는 ProjectTo 가 커버 -> 제거" },
-      { h: "검증: MD5로 응답 동일성까지" },
-      { p: "성능은 좋아졌지만 응답이 그대로인가가 더 중요했다. 최적화 전/후 응답 payload를 엔드포인트 7개 x 언어 5개 조합으로 뽑아 MD5가 바이트 단위로 동일한지 비교했다. 전부 일치 — 회귀 0." },
-      { h: "결과" },
-      { ul: [
-        "v1 상세: 91초 → 0.04초",
-        "v2 목록: 180초 타임아웃 → 0.26초",
-        "중간 물질화 행: 약 1.38억 → 수천 단위",
-        "응답 payload: MD5 동일(회귀 0)",
-      ] },
-      { p: "ProjectTo를 쓴다고 Include가 자동으로 무해해지지 않는다. 그리고 빨라졌다는 항상 결과가 같다와 함께 증명해야 신뢰할 수 있다 — 생성 SQL과 payload 해시를 같이 보는 습관이 결정적이었다." },
-    ],
-  },
-  {
-    slug: "polly-http-resilience",
-    title: "Polly로 HTTP 복원력 계층 만들기 — 333건 장애 대응기",
-    date: "2026-06-20",
-    category: "Backend",
-    tags: ["Polly", ".NET", "Resilience"],
-    gradient: "from-[#0f9d8f] to-[#0a544c]",
-    summary:
-      "전이성(transient) 네트워크·5xx 실패로 쌓인 333건의 자동 리포트를, 지수 백오프 재시도와 토큰 캐싱으로 구조적으로 줄인 이야기.",
-    body: [
-      { h: "문제" },
-      { p: "HttpRequestException이 자동 리포트로 333건 쌓여 있었다. 대부분 일시적인 네트워크·5xx·토큰 발급 타임아웃이었는데, 재시도 정책이 없어 한 번 실패하면 그대로 장애로 기록됐다." },
-      { h: "해결" },
-      { p: "Microsoft.Extensions.Http.Polly로 솔루션 전반에 복원력 계층을 도입했다. 5xx·408·429·TaskCanceledException에 대해 지수 백오프(2→4→8초, 3회) 재시도를 걸고, Revalidate/AI 호출의 과도한 타임아웃을 30~60초로 조였다." },
-      { code: "services.AddHttpClient(\"revalidate\")\n  .AddTransientHttpErrorPolicy(p =>\n    p.WaitAndRetryAsync(3, r => TimeSpan.FromSeconds(Math.Pow(2, r))));" },
-      { p: "추가로 Azure AD 토큰을 Singleton 캐시(SemaphoreSlim double-check)로 감싸 배치당 N회 발급을 1회로 줄였고, 실패를 성공으로 기록하던 silent-failure 안티패턴을 제거해 실제 실패가 재시도 큐로 올라오게 했다." },
-    ],
-  },
-  {
-    slug: "cosmos-server-side-query",
-    title: "Cosmos DB 클라이언트측 → 서버측 쿼리 마이그레이션",
-    date: "2026-05-30",
-    category: "Performance",
-    tags: ["Cosmos DB", "Query", "C#"],
-    gradient: "from-[#8e5cf7] to-[#5b32b0]",
-    summary:
-      "메모리로 다 끌어와 필터링하던 채팅 세션 조회를 서버측 쿼리로 옮겨 RU와 지연을 줄인 과정.",
-    body: [
-      { h: "문제" },
-      { p: "채팅 세션 조회가 파티션의 문서를 클라이언트로 모두 가져온 뒤 메모리에서 필터링하고 있었다. 세션이 쌓일수록 RU 소비와 지연이 선형으로 늘었다." },
-      { h: "해결" },
-      { p: "필터·정렬을 서버측 SQL 쿼리로 내려 필요한 문서만 받도록 바꾸고, 파티션 키를 쿼리에 명시해 크로스 파티션 팬아웃을 피했다. 페이지네이션은 continuation token 기반으로 정리했다." },
-      { p: "핵심은 '가져와서 거르기'가 아니라 '거른 걸 가져오기'. 데이터가 커질수록 이 차이가 비용·지연으로 그대로 드러난다." },
-    ],
-  },
-  {
-    slug: "signalr-crossorigin-jwt",
-    title: "SignalR 크로스오리진 JWT 인증 삽질기",
-    date: "2026-05-15",
-    category: "Backend",
-    tags: ["SignalR", "JWT", "CORS"],
-    gradient: "from-[#e0685f] to-[#b23b32]",
-    summary:
-      "WebSocket 업그레이드에서 토큰이 안 실려 허브 연결이 실패하던 문제를, CORS·쿼리스트링 토큰·클라이언트 팩토리 3박자로 해결.",
-    body: [
-      { h: "문제" },
-      { p: "프로덕션에서 SignalR 허브 연결이 간헐적으로 실패했다. WebSocket 업그레이드 요청에는 Authorization 헤더가 실리지 않아 서버가 인증을 못 했고, 크로스오리진 자격증명도 막혀 있었다." },
-      { h: "해결 3박자" },
-      { ul: [
-        "CORS: AllowCredentials + SetIsOriginAllowed 로 자격증명 허용",
-        "서버: JwtBearer OnMessageReceived 에서 access_token 쿼리스트링을 읽어 인증",
-        "클라이언트: accessTokenFactory 로 토큰을 연결마다 주입",
-      ] },
-      { code: "options.Events = new JwtBearerEvents {\n  OnMessageReceived = ctx => {\n    var token = ctx.Request.Query[\"access_token\"];\n    if (!string.IsNullOrEmpty(token)) ctx.Token = token;\n    return Task.CompletedTask;\n  }\n};" },
-      { p: "셋 중 하나만 빠져도 조용히 실패한다. WebSocket 인증은 HTTP 인증과 경로가 다르다는 걸 체감한 사례." },
-    ],
-  },
-]
-
-export const getPost = (slug: string): Post | undefined =>
-  posts.find((p) => p.slug === slug)
 
 // 본문 글자 수 기반 읽기시간(분). 한국어 ~500자/분 기준.
 export function readingMinutes(post: Post): number {
@@ -120,11 +29,11 @@ export function readingMinutes(post: Post): number {
   return Math.max(1, Math.round(text.replace(/\s/g, "").length / 500))
 }
 
-// 목록 순서 기준 이전/다음 글 (배열 앞쪽이 최신)
-export function getAdjacent(slug: string): { prev: Post | null; next: Post | null } {
-  const i = posts.findIndex((p) => p.slug === slug)
-  return {
-    prev: i >= 0 && i < posts.length - 1 ? posts[i + 1] : null, // 더 오래된 글
-    next: i > 0 ? posts[i - 1] : null, // 더 최신 글
+// 글 목록에서 카테고리 탭 목록을 만든다: ["All", ...등장 순서 고유 카테고리]
+export function deriveCategories(posts: Post[]): string[] {
+  const seen: string[] = []
+  for (const p of posts) {
+    if (p.category && !seen.includes(p.category)) seen.push(p.category)
   }
+  return ["All", ...seen]
 }

--- a/lib/postsData.ts
+++ b/lib/postsData.ts
@@ -1,0 +1,197 @@
+import type { Block, Post } from "./posts"
+import { TOKEN, BLOG_DATABASE_ID } from "../config"
+import { fallbackPosts } from "./postsFallback"
+
+// ── Notion 블로그 DB 스키마(속성명) ──────────────────────────────
+// 사용자가 Notion 에서 만드는 DB 의 속성 이름과 정확히 일치해야 한다.
+// PR-C(쓰기)도 동일한 상수를 재사용한다.
+export const BLOG_PROPS = {
+  title: "Title",
+  slug: "Slug",
+  date: "Date",
+  category: "Category",
+  tags: "Tags",
+  summary: "Summary",
+  published: "Published",
+} as const
+
+const NOTION_API = "https://api.notion.com/v1"
+const NOTION_VERSION = "2022-06-28"
+const REVALIDATE = 3600
+
+function headers() {
+  return {
+    accept: "application/json",
+    "Notion-Version": NOTION_VERSION,
+    "content-type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  }
+}
+
+// ── Notion 응답 중 실제 사용하는 필드만 최소 정의 ────────────────
+interface NotionRichText {
+  plain_text?: string
+}
+interface NotionPage {
+  id: string
+  properties?: Record<string, unknown>
+}
+interface NotionBlock {
+  type?: string
+  heading_1?: { rich_text?: NotionRichText[] }
+  heading_2?: { rich_text?: NotionRichText[] }
+  heading_3?: { rich_text?: NotionRichText[] }
+  paragraph?: { rich_text?: NotionRichText[] }
+  code?: { rich_text?: NotionRichText[] }
+  bulleted_list_item?: { rich_text?: NotionRichText[] }
+  numbered_list_item?: { rich_text?: NotionRichText[] }
+}
+
+function plain(rt?: NotionRichText[]): string {
+  return (rt || []).map((t) => t.plain_text ?? "").join("")
+}
+
+// Notion property 접근 헬퍼 (구조가 느슨해 안전하게 캐스팅)
+function prop(page: NotionPage, name: string): Record<string, unknown> | undefined {
+  const p = page.properties?.[name]
+  return p as Record<string, unknown> | undefined
+}
+
+function readTitle(page: NotionPage, name: string): string {
+  const t = prop(page, name)?.title as NotionRichText[] | undefined
+  return plain(t)
+}
+function readRichText(page: NotionPage, name: string): string {
+  const t = prop(page, name)?.rich_text as NotionRichText[] | undefined
+  return plain(t)
+}
+function readSelect(page: NotionPage, name: string): string {
+  const s = prop(page, name)?.select as { name?: string } | undefined
+  return s?.name ?? ""
+}
+function readMultiSelect(page: NotionPage, name: string): string[] {
+  const m = prop(page, name)?.multi_select as { name?: string }[] | undefined
+  return (m || []).map((o) => o.name ?? "").filter(Boolean)
+}
+function readDate(page: NotionPage, name: string): string {
+  const d = prop(page, name)?.date as { start?: string } | undefined
+  return d?.start ?? ""
+}
+
+// 페이지 하위 블록을 조회해 렌더용 Block[] 로 변환.
+// 연속된 목록 아이템은 하나의 { ul } 로 묶는다.
+async function fetchBody(pageId: string): Promise<Block[]> {
+  const res = await fetch(
+    `${NOTION_API}/blocks/${pageId}/children?page_size=100`,
+    { headers: headers(), next: { revalidate: REVALIDATE } }
+  )
+  if (!res.ok) throw new Error(`Notion blocks ${res.status}`)
+  const json = (await res.json()) as { results?: NotionBlock[] }
+
+  const blocks: Block[] = []
+  let listBuf: string[] = []
+  const flushList = () => {
+    if (listBuf.length) {
+      blocks.push({ ul: listBuf })
+      listBuf = []
+    }
+  }
+
+  for (const b of json.results || []) {
+    switch (b.type) {
+      case "heading_1":
+      case "heading_2":
+      case "heading_3": {
+        flushList()
+        const h = plain(b[b.type]?.rich_text)
+        if (h) blocks.push({ h })
+        break
+      }
+      case "paragraph": {
+        flushList()
+        const p = plain(b.paragraph?.rich_text)
+        if (p.trim()) blocks.push({ p })
+        break
+      }
+      case "code": {
+        flushList()
+        const code = plain(b.code?.rich_text)
+        if (code) blocks.push({ code })
+        break
+      }
+      case "bulleted_list_item":
+      case "numbered_list_item": {
+        const li = plain(b[b.type]?.rich_text)
+        if (li) listBuf.push(li)
+        break
+      }
+      default:
+        flushList()
+    }
+  }
+  flushList()
+  return blocks
+}
+
+async function mapPage(page: NotionPage): Promise<Post> {
+  const slug = readRichText(page, BLOG_PROPS.slug) || page.id
+  const body = await fetchBody(page.id)
+  return {
+    slug,
+    title: readTitle(page, BLOG_PROPS.title),
+    date: readDate(page, BLOG_PROPS.date),
+    category: readSelect(page, BLOG_PROPS.category),
+    tags: readMultiSelect(page, BLOG_PROPS.tags),
+    summary: readRichText(page, BLOG_PROPS.summary),
+    body,
+  }
+}
+
+// 발행된 블로그 글을 최신순으로 반환. Notion 미설정/실패/빈 결과면 시드로 fallback.
+export async function getPosts(): Promise<Post[]> {
+  if (!TOKEN || !BLOG_DATABASE_ID) return fallbackPosts
+
+  try {
+    const res = await fetch(
+      `${NOTION_API}/databases/${BLOG_DATABASE_ID}/query`,
+      {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({
+          filter: { property: BLOG_PROPS.published, checkbox: { equals: true } },
+          sorts: [{ property: BLOG_PROPS.date, direction: "descending" }],
+          page_size: 100,
+        }),
+        next: { revalidate: REVALIDATE },
+      }
+    )
+    if (!res.ok) throw new Error(`Notion API ${res.status}`)
+    const json = (await res.json()) as { results?: NotionPage[] }
+
+    const pages = json.results || []
+    if (pages.length === 0) return fallbackPosts
+
+    const posts = await Promise.all(pages.map(mapPage))
+    return posts.filter((p) => p.title)
+  } catch (e) {
+    console.error("[posts] Notion fetch failed:", (e as Error).message)
+    return fallbackPosts
+  }
+}
+
+export async function getPost(slug: string): Promise<Post | undefined> {
+  const posts = await getPosts()
+  return posts.find((p) => p.slug === slug)
+}
+
+// 목록 순서 기준 이전/다음 글 (배열 앞쪽이 최신)
+export async function getAdjacent(
+  slug: string
+): Promise<{ prev: Post | null; next: Post | null }> {
+  const posts = await getPosts()
+  const i = posts.findIndex((p) => p.slug === slug)
+  return {
+    prev: i >= 0 && i < posts.length - 1 ? posts[i + 1] : null, // 더 오래된 글
+    next: i > 0 ? posts[i - 1] : null, // 더 최신 글
+  }
+}

--- a/lib/postsFallback.ts
+++ b/lib/postsFallback.ts
@@ -1,0 +1,92 @@
+import type { Post } from "./posts"
+
+// Notion 블로그 DB 가 없거나(로컬/미설정) 조회가 비었을 때 사용하는 시드 글.
+// 배열 앞쪽이 최신(내림차순).
+export const fallbackPosts: Post[] = [
+  {
+    slug: "ef-core-cartesian-explosion",
+    title: "EF Core 카테시안 폭발로 91초 걸리던 API를 0.04초로",
+    date: "2026-07-06",
+    category: "Performance",
+    tags: ["EF Core", "C#", "Performance"],
+    gradient: "from-[#2383e2] to-[#0b6bcb]",
+    summary:
+      "ProjectTo가 있는데도 남아 있던 Include가 만든 1.38억 row의 카테시안 폭발을 AsSplitQuery로 잡고, MD5로 응답 동일성까지 검증한 과정.",
+    body: [
+      { h: "증상: 1.38억 row의 카테시안 폭발" },
+      { p: "병원 목록 API에서 프로덕션 SQL 타임아웃이 반복됐다. 특정 상세 엔드포인트 하나가 전체 장애의 절반을 차지했고, 응답까지 91초가 걸렸다. AutoMapper ProjectTo로 필요한 컬럼만 투영하고 있어 무거울 이유가 없어 보였는데, 실제 생성 SQL은 전혀 달랐다." },
+      { p: "문제는 ProjectTo가 커버하는 프로젝션 위에 Include/ThenInclude 체인이 그대로 남아 있던 것. 여러 컬렉션을 한 쿼리로 조인하면서 행이 곱셈으로 폭발했다. COUNT_BIG으로 중간 물질화 행 수를 재보니 단일 쿼리가 약 1.38억 row를 만들고 있었다." },
+      { code: "-- 컬렉션 4개가 한 쿼리에서 곱해지며 중간 행 폭발\nSELECT ... FROM Hospitals h\n  LEFT JOIN Departments ...\n  LEFT JOIN Doctors ...\n  LEFT JOIN Translations ...   -- N x M x K x ...\n=> 138,523,392 rows materialized" },
+      { h: "해결: 불필요한 Include 제거 + 선택적 AsSplitQuery" },
+      { p: "프로젝션이 이미 커버하는 Include는 제거하고, 깊은 컬렉션을 다루는 핸들러에만 AsSplitQuery()를 적용해 하나의 카테시안 쿼리를 여러 개의 작은 쿼리로 분리했다. 곱셈이 덧셈으로 바뀌면서 중간 행 수가 수천 단위로 떨어졌다." },
+      { code: "var query = _db.Hospitals\n    .Where(predicate)\n    .AsSplitQuery()              // 곱집합 -> 분리 쿼리\n    .ProjectTo<HospitalDto>(_mapper.ConfigurationProvider);\n// Include/ThenInclude 는 ProjectTo 가 커버 -> 제거" },
+      { h: "검증: MD5로 응답 동일성까지" },
+      { p: "성능은 좋아졌지만 응답이 그대로인가가 더 중요했다. 최적화 전/후 응답 payload를 엔드포인트 7개 x 언어 5개 조합으로 뽑아 MD5가 바이트 단위로 동일한지 비교했다. 전부 일치 — 회귀 0." },
+      { h: "결과" },
+      { ul: [
+        "v1 상세: 91초 → 0.04초",
+        "v2 목록: 180초 타임아웃 → 0.26초",
+        "중간 물질화 행: 약 1.38억 → 수천 단위",
+        "응답 payload: MD5 동일(회귀 0)",
+      ] },
+      { p: "ProjectTo를 쓴다고 Include가 자동으로 무해해지지 않는다. 그리고 빨라졌다는 항상 결과가 같다와 함께 증명해야 신뢰할 수 있다 — 생성 SQL과 payload 해시를 같이 보는 습관이 결정적이었다." },
+    ],
+  },
+  {
+    slug: "polly-http-resilience",
+    title: "Polly로 HTTP 복원력 계층 만들기 — 333건 장애 대응기",
+    date: "2026-06-20",
+    category: "Backend",
+    tags: ["Polly", ".NET", "Resilience"],
+    gradient: "from-[#0f9d8f] to-[#0a544c]",
+    summary:
+      "전이성(transient) 네트워크·5xx 실패로 쌓인 333건의 자동 리포트를, 지수 백오프 재시도와 토큰 캐싱으로 구조적으로 줄인 이야기.",
+    body: [
+      { h: "문제" },
+      { p: "HttpRequestException이 자동 리포트로 333건 쌓여 있었다. 대부분 일시적인 네트워크·5xx·토큰 발급 타임아웃이었는데, 재시도 정책이 없어 한 번 실패하면 그대로 장애로 기록됐다." },
+      { h: "해결" },
+      { p: "Microsoft.Extensions.Http.Polly로 솔루션 전반에 복원력 계층을 도입했다. 5xx·408·429·TaskCanceledException에 대해 지수 백오프(2→4→8초, 3회) 재시도를 걸고, Revalidate/AI 호출의 과도한 타임아웃을 30~60초로 조였다." },
+      { code: "services.AddHttpClient(\"revalidate\")\n  .AddTransientHttpErrorPolicy(p =>\n    p.WaitAndRetryAsync(3, r => TimeSpan.FromSeconds(Math.Pow(2, r))));" },
+      { p: "추가로 Azure AD 토큰을 Singleton 캐시(SemaphoreSlim double-check)로 감싸 배치당 N회 발급을 1회로 줄였고, 실패를 성공으로 기록하던 silent-failure 안티패턴을 제거해 실제 실패가 재시도 큐로 올라오게 했다." },
+    ],
+  },
+  {
+    slug: "cosmos-server-side-query",
+    title: "Cosmos DB 클라이언트측 → 서버측 쿼리 마이그레이션",
+    date: "2026-05-30",
+    category: "Performance",
+    tags: ["Cosmos DB", "Query", "C#"],
+    gradient: "from-[#8e5cf7] to-[#5b32b0]",
+    summary:
+      "메모리로 다 끌어와 필터링하던 채팅 세션 조회를 서버측 쿼리로 옮겨 RU와 지연을 줄인 과정.",
+    body: [
+      { h: "문제" },
+      { p: "채팅 세션 조회가 파티션의 문서를 클라이언트로 모두 가져온 뒤 메모리에서 필터링하고 있었다. 세션이 쌓일수록 RU 소비와 지연이 선형으로 늘었다." },
+      { h: "해결" },
+      { p: "필터·정렬을 서버측 SQL 쿼리로 내려 필요한 문서만 받도록 바꾸고, 파티션 키를 쿼리에 명시해 크로스 파티션 팬아웃을 피했다. 페이지네이션은 continuation token 기반으로 정리했다." },
+      { p: "핵심은 '가져와서 거르기'가 아니라 '거른 걸 가져오기'. 데이터가 커질수록 이 차이가 비용·지연으로 그대로 드러난다." },
+    ],
+  },
+  {
+    slug: "signalr-crossorigin-jwt",
+    title: "SignalR 크로스오리진 JWT 인증 삽질기",
+    date: "2026-05-15",
+    category: "Backend",
+    tags: ["SignalR", "JWT", "CORS"],
+    gradient: "from-[#e0685f] to-[#b23b32]",
+    summary:
+      "WebSocket 업그레이드에서 토큰이 안 실려 허브 연결이 실패하던 문제를, CORS·쿼리스트링 토큰·클라이언트 팩토리 3박자로 해결.",
+    body: [
+      { h: "문제" },
+      { p: "프로덕션에서 SignalR 허브 연결이 간헐적으로 실패했다. WebSocket 업그레이드 요청에는 Authorization 헤더가 실리지 않아 서버가 인증을 못 했고, 크로스오리진 자격증명도 막혀 있었다." },
+      { h: "해결 3박자" },
+      { ul: [
+        "CORS: AllowCredentials + SetIsOriginAllowed 로 자격증명 허용",
+        "서버: JwtBearer OnMessageReceived 에서 access_token 쿼리스트링을 읽어 인증",
+        "클라이언트: accessTokenFactory 로 토큰을 연결마다 주입",
+      ] },
+      { code: "options.Events = new JwtBearerEvents {\n  OnMessageReceived = ctx => {\n    var token = ctx.Request.Query[\"access_token\"];\n    if (!string.IsNullOrEmpty(token)) ctx.Token = token;\n    return Task.CompletedTask;\n  }\n};" },
+      { p: "셋 중 하나만 빠져도 조용히 실패한다. WebSocket 인증은 HTTP 인증과 경로가 다르다는 걸 체감한 사례." },
+    ],
+  },
+]


### PR DESCRIPTION
## 요약
하드코딩돼 있던 블로그 글을 **Notion DB(CMS)** 에서 읽어오도록 이관한다. 프로젝트(`lib/notion.ts`)와 동일한 **fetch + fallback** 패턴. 이 PR은 **읽기만** 다룬다(쓰기는 PR-C).

Closes #28

## 변경
- `lib/postsData.ts` (신규): `getPosts/getPost/getAdjacent` — `NOTION_BLOG_DB` 쿼리 + 페이지 블록 → 렌더 `Block[]` 매핑(heading/paragraph/code/list). Published 필터, Date 내림차순
- `lib/posts.ts`: 서버 fetch 제거 → **타입·`readingMinutes`·`deriveCategories`** 만 남긴 순수 모듈(client 안전)
- `lib/postsFallback.ts` (신규): 기존 시드 글 이동
- `blog/page.tsx`: async 서버 컴포넌트 → `getPosts` 후 `BlogIndex` 에 props 주입
- `components/blogIndex.tsx`: 데이터 직접 import 제거, `posts`/`categories` props 수신
- `blog/[slug]/page.tsx`: `getPost`/`getAdjacent`/`generateStaticParams` async 화
- `config`: `BLOG_DATABASE_ID`

## 안전성
- **`NOTION_BLOG_DB` 미설정/조회 실패/빈 결과 시 기존 시드 글로 fallback** — 로컬 `next build` 통과 확인(현재 시드 4개로 정적 생성)
- client(`BlogIndex`)는 서버 fetch 모듈을 import 하지 않음

## 병합 후 활성화 (배포자)
1. Notion 블로그 DB 생성: **Title**(title)·**Slug**(rich_text)·**Date**(date)·**Category**(select)·**Tags**(multi_select)·**Summary**(rich_text)·**Published**(checkbox). 본문은 페이지 블록
2. 통합에 DB 공유(읽기 권한) → `NOTION_BLOG_DB` env(Vercel + 로컬)
3. Published 체크된 글이 최신순으로 노출됨

## 후속
- PR-C: `/admin` 에서 이 DB 로 **쓰기**(블로그·프로젝트 등록)