### PR TITLE
feat(admin): /admin 콘텐츠 쓰기 — 블로그·프로젝트 Notion 등록 (PR-C)

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,0 +1,88 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { auth } from "@/auth"
+import { createBlogPage, createProjectPage } from "../../lib/notionWrite"
+
+export interface ActionState {
+  ok: boolean
+  message: string
+}
+
+function parseTags(raw: string): string[] {
+  return (raw || "")
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean)
+}
+
+function slugify(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w가-힣]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+// 모든 쓰기 액션은 세션을 재확인한다(미들웨어에 더해 방어).
+async function requireOwner(): Promise<string | null> {
+  const session = await auth()
+  return session?.user ? null : "인증이 필요합니다. 다시 로그인하세요."
+}
+
+export async function submitBlog(
+  _prev: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const authError = await requireOwner()
+  if (authError) return { ok: false, message: authError }
+
+  const title = String(formData.get("title") || "").trim()
+  if (!title) return { ok: false, message: "제목은 필수입니다." }
+
+  try {
+    await createBlogPage({
+      title,
+      slug: String(formData.get("slug") || "").trim() || slugify(title),
+      date: String(formData.get("date") || "").trim(),
+      category: String(formData.get("category") || "").trim(),
+      tags: parseTags(String(formData.get("tags") || "")),
+      summary: String(formData.get("summary") || "").trim(),
+      body: String(formData.get("body") || ""),
+      published: formData.get("published") === "on",
+    })
+    revalidatePath("/blog")
+    revalidatePath("/")
+    return { ok: true, message: `“${title}” 글을 Notion 에 등록했습니다.` }
+  } catch (e) {
+    return { ok: false, message: (e as Error).message }
+  }
+}
+
+export async function submitProject(
+  _prev: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const authError = await requireOwner()
+  if (authError) return { ok: false, message: authError }
+
+  const name = String(formData.get("name") || "").trim()
+  if (!name) return { ok: false, message: "프로젝트명은 필수입니다." }
+
+  try {
+    await createProjectPage({
+      name,
+      description: String(formData.get("description") || "").trim(),
+      tags: parseTags(String(formData.get("tags") || "")),
+      github: String(formData.get("github") || "").trim(),
+      startDate: String(formData.get("startDate") || "").trim(),
+      endDate: String(formData.get("endDate") || "").trim(),
+      status: String(formData.get("status") || "").trim(),
+    })
+    revalidatePath("/projects")
+    revalidatePath("/")
+    return { ok: true, message: `“${name}” 프로젝트를 Notion 에 등록했습니다.` }
+  } catch (e) {
+    return { ok: false, message: (e as Error).message }
+  }
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { auth, signOut } from "@/auth"
+import AdminForms from "../../components/admin/adminForms"
 
 // 검색엔진 비노출(민감 관리 페이지). 미들웨어가 접근 자체를 인증으로 막지만,
 // 색인/링크 노출도 이중으로 차단한다.
@@ -20,15 +21,10 @@ export default async function AdminPage() {
       <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Admin</p>
       <h1 className="mt-3 text-2xl font-semibold text-fg">콘텐츠 관리</h1>
       <p className="mt-2 text-sm text-muted">
-        {name}님으로 로그인됨. 블로그·프로젝트·문의 관리는 다음 단계에서 추가됩니다.
+        {name}님으로 로그인됨. 블로그·프로젝트를 Notion 에 직접 등록할 수 있습니다.
       </p>
 
-      {/* 후속 PR에서 채워질 자리 (PR-C: 쓰기 폼 / PR-D: 문의 목록) */}
-      <div className="mt-8 grid gap-3">
-        <div className="card p-5 text-sm text-muted">블로그 작성 · 목록 <span className="text-xs">(예정 — PR-C)</span></div>
-        <div className="card p-5 text-sm text-muted">프로젝트 등록 · 목록 <span className="text-xs">(예정 — PR-C)</span></div>
-        <div className="card p-5 text-sm text-muted">문의(이메일·면접 요청) 확인 <span className="text-xs">(예정 — PR-D)</span></div>
-      </div>
+      <AdminForms />
 
       <form
         action={async () => {

--- a/components/admin/adminForms.tsx
+++ b/components/admin/adminForms.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useActionState, useState } from "react"
+import { submitBlog, submitProject, type ActionState } from "../../app/admin/actions"
+
+const INIT: ActionState = { ok: false, message: "" }
+
+const fieldCls =
+  "mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-fg outline-none focus-visible:ring-2 focus-visible:ring-accent"
+const labelCls = "block text-xs font-medium uppercase tracking-wide text-muted"
+
+function Field({
+  label,
+  name,
+  type = "text",
+  placeholder,
+  required,
+}: {
+  label: string
+  name: string
+  type?: string
+  placeholder?: string
+  required?: boolean
+}) {
+  return (
+    <label className="block">
+      <span className={labelCls}>
+        {label}
+        {required && <span className="text-accent"> *</span>}
+      </span>
+      <input type={type} name={name} placeholder={placeholder} required={required} className={fieldCls} />
+    </label>
+  )
+}
+
+function Status({ state }: { state: ActionState }) {
+  if (!state.message) return null
+  return (
+    <p
+      className={`mt-3 rounded-md px-3 py-2 text-sm ${
+        state.ok
+          ? "bg-accent/10 text-accent"
+          : "border border-line text-muted"
+      }`}
+      role="status"
+    >
+      {state.message}
+    </p>
+  )
+}
+
+function BlogForm() {
+  const [state, action, pending] = useActionState(submitBlog, INIT)
+  return (
+    <form action={action} className="grid gap-4">
+      <Field label="제목" name="title" placeholder="글 제목" required />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="Slug" name="slug" placeholder="비우면 제목에서 생성" />
+        <Field label="날짜" name="date" type="date" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="카테고리" name="category" placeholder="Performance / Backend …" />
+        <Field label="태그 (쉼표로 구분)" name="tags" placeholder="EF Core, C#" />
+      </div>
+      <label className="block">
+        <span className={labelCls}>요약</span>
+        <textarea name="summary" rows={2} className={fieldCls} placeholder="목록에 보일 한두 문장" />
+      </label>
+      <label className="block">
+        <span className={labelCls}>본문 (마크다운 유사: # 제목, ``` 코드, - 목록)</span>
+        <textarea name="body" rows={12} className={`${fieldCls} font-mono`} placeholder={"## 소제목\n문단 내용...\n\n- 목록 항목\n\n```\n코드\n```"} />
+      </label>
+      <label className="flex items-center gap-2 text-sm text-fg">
+        <input type="checkbox" name="published" defaultChecked className="h-4 w-4 rounded border-line" />
+        바로 발행 (Published)
+      </label>
+      <div>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {pending ? "등록 중…" : "블로그 글 등록"}
+        </button>
+      </div>
+      <Status state={state} />
+    </form>
+  )
+}
+
+function ProjectForm() {
+  const [state, action, pending] = useActionState(submitProject, INIT)
+  return (
+    <form action={action} className="grid gap-4">
+      <Field label="프로젝트명" name="name" placeholder="프로젝트 이름" required />
+      <label className="block">
+        <span className={labelCls}>설명</span>
+        <textarea name="description" rows={3} className={fieldCls} placeholder="한두 문장 요약" />
+      </label>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="태그 (쉼표로 구분)" name="tags" placeholder="C#, Azure" />
+        <Field label="GitHub / 링크" name="github" placeholder="https://github.com/…" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Field label="시작일" name="startDate" type="date" />
+        <Field label="종료일" name="endDate" type="date" />
+        <Field label="상태 (status 옵션명)" name="status" placeholder="Done" />
+      </div>
+      <div>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {pending ? "등록 중…" : "프로젝트 등록"}
+        </button>
+      </div>
+      <Status state={state} />
+    </form>
+  )
+}
+
+export default function AdminForms() {
+  const [tab, setTab] = useState<"blog" | "project">("blog")
+  return (
+    <div className="mt-8">
+      <div className="mb-6 flex gap-2 border-b border-line pb-3">
+        {(["blog", "project"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+              tab === t ? "bg-accent text-white" : "border border-line text-muted hover:bg-surface hover:text-fg"
+            }`}
+          >
+            {t === "blog" ? "블로그" : "프로젝트"}
+          </button>
+        ))}
+      </div>
+      {tab === "blog" ? <BlogForm /> : <ProjectForm />}
+    </div>
+  )
+}

--- a/lib/notionWrite.ts
+++ b/lib/notionWrite.ts
@@ -1,0 +1,170 @@
+// Notion 쓰기(페이지 생성) 헬퍼. 서버(Server Action)에서만 호출한다.
+// 읽기(lib/postsData.ts, lib/notion.ts)와 동일한 REST API·속성명을 재사용한다.
+import { TOKEN, DATABASE_ID, BLOG_DATABASE_ID } from "../config"
+import { BLOG_PROPS } from "./postsData"
+
+const NOTION_API = "https://api.notion.com/v1"
+const NOTION_VERSION = "2022-06-28"
+
+// 프로젝트 DB 속성명 (lib/notion.ts 읽기 매핑과 일치)
+export const PROJECT_PROPS = {
+  name: "projectName",
+  description: "description",
+  tags: "tag",
+  github: "github",
+  workPeriod: "workPeriod",
+  status: "status",
+} as const
+
+function headers() {
+  return {
+    accept: "application/json",
+    "Notion-Version": NOTION_VERSION,
+    "content-type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  }
+}
+
+// Notion rich_text 는 항목당 content 2000자 제한 → 안전하게 청크로 분할.
+function rich(content: string) {
+  const text = content ?? ""
+  if (!text) return []
+  const chunks: string[] = []
+  for (let i = 0; i < text.length; i += 2000) chunks.push(text.slice(i, i + 2000))
+  return chunks.map((c) => ({ type: "text", text: { content: c } }))
+}
+
+function block(type: string, content: string, extra: Record<string, unknown> = {}) {
+  return {
+    object: "block",
+    type,
+    [type]: { rich_text: rich(content), ...extra },
+  }
+}
+
+// 마크다운 유사 본문 텍스트 → Notion 블록 배열.
+// 지원: # / ## / ### 헤딩, ``` 코드펜스, - / * 목록, 그 외 문단(빈 줄로 분리).
+export function textToBlocks(src: string): Record<string, unknown>[] {
+  const lines = (src ?? "").replace(/\r\n/g, "\n").split("\n")
+  const blocks: Record<string, unknown>[] = []
+  let para: string[] = []
+  let inCode = false
+  let codeBuf: string[] = []
+
+  const flushPara = () => {
+    if (para.length) {
+      const t = para.join(" ").trim()
+      if (t) blocks.push(block("paragraph", t))
+      para = []
+    }
+  }
+
+  for (const line of lines) {
+    const fence = line.trim().startsWith("```")
+    if (fence) {
+      if (inCode) {
+        blocks.push(block("code", codeBuf.join("\n"), { language: "plain text" }))
+        codeBuf = []
+        inCode = false
+      } else {
+        flushPara()
+        inCode = true
+      }
+      continue
+    }
+    if (inCode) {
+      codeBuf.push(line)
+      continue
+    }
+
+    const h = line.match(/^(#{1,3})\s+(.*)$/)
+    const li = line.match(/^[-*]\s+(.*)$/)
+    if (h) {
+      flushPara()
+      const level = h[1].length
+      blocks.push(block(`heading_${level}`, h[2].trim()))
+    } else if (li) {
+      flushPara()
+      blocks.push(block("bulleted_list_item", li[1].trim()))
+    } else if (line.trim() === "") {
+      flushPara()
+    } else {
+      para.push(line.trim())
+    }
+  }
+  if (inCode && codeBuf.length) blocks.push(block("code", codeBuf.join("\n"), { language: "plain text" }))
+  flushPara()
+  return blocks
+}
+
+async function createPage(body: Record<string, unknown>) {
+  const res = await fetch(`${NOTION_API}/pages`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "")
+    throw new Error(`Notion 페이지 생성 실패 (${res.status}): ${detail.slice(0, 300)}`)
+  }
+  return (await res.json()) as { id: string }
+}
+
+export interface BlogInput {
+  title: string
+  slug: string
+  date: string
+  category: string
+  tags: string[]
+  summary: string
+  body: string
+  published: boolean
+}
+
+export async function createBlogPage(input: BlogInput): Promise<{ id: string }> {
+  if (!TOKEN || !BLOG_DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_BLOG_DB 미설정")
+
+  const properties: Record<string, unknown> = {
+    [BLOG_PROPS.title]: { title: rich(input.title) },
+    [BLOG_PROPS.slug]: { rich_text: rich(input.slug) },
+    [BLOG_PROPS.summary]: { rich_text: rich(input.summary) },
+    [BLOG_PROPS.tags]: { multi_select: input.tags.map((name) => ({ name })) },
+    [BLOG_PROPS.published]: { checkbox: input.published },
+  }
+  if (input.date) properties[BLOG_PROPS.date] = { date: { start: input.date } }
+  if (input.category) properties[BLOG_PROPS.category] = { select: { name: input.category } }
+
+  return createPage({
+    parent: { database_id: BLOG_DATABASE_ID },
+    properties,
+    children: textToBlocks(input.body),
+  })
+}
+
+export interface ProjectInput {
+  name: string
+  description: string
+  tags: string[]
+  github: string
+  startDate: string
+  endDate: string
+  status: string
+}
+
+export async function createProjectPage(input: ProjectInput): Promise<{ id: string }> {
+  if (!TOKEN || !DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_DB 미설정")
+
+  const properties: Record<string, unknown> = {
+    [PROJECT_PROPS.name]: { title: rich(input.name) },
+    [PROJECT_PROPS.description]: { rich_text: rich(input.description) },
+    [PROJECT_PROPS.tags]: { multi_select: input.tags.map((name) => ({ name })) },
+  }
+  if (input.github) properties[PROJECT_PROPS.github] = { url: input.github }
+  if (input.startDate)
+    properties[PROJECT_PROPS.workPeriod] = {
+      date: { start: input.startDate, end: input.endDate || null },
+    }
+  if (input.status) properties[PROJECT_PROPS.status] = { status: { name: input.status } }
+
+  return createPage({ parent: { database_id: DATABASE_ID }, properties })
+}


### PR DESCRIPTION
## 요약
인증된 `/admin` 에서 **블로그 글·프로젝트를 Notion DB 에 직접 등록**한다. Notion 앱을 열지 않고 사이트에서 지속 업데이트.

Closes #30

> ⚠️ **PR-B(#29) 위에 스택**된 PR입니다. base 가 `feat/28-blog-notion` 이며, PR-B 가 dev 로 병합되면 GitHub 가 base 를 자동으로 dev 로 재지정합니다. **PR-B 를 먼저 병합**하세요.

## 변경
- `lib/notionWrite.ts`: `POST /v1/pages` 로 블로그/프로젝트 페이지 생성. 본문(마크다운 유사: `#` 제목·``` 코드·`-` 목록) → Notion 블록 변환, rich_text 2000자 청크 분할. `BLOG_PROPS`/`PROJECT_PROPS` 로 읽기 매핑과 속성명 일원화
- `app/admin/actions.ts`: Server Action(`submitBlog`/`submitProject`) — 제출마다 **세션 재확인**, 성공 시 `/blog`·`/projects`·`/` revalidate
- `components/admin/adminForms.tsx`: 블로그/프로젝트 **탭 폼**(`useActionState`, 진행/성공/오류 표시)
- `app/admin/page.tsx`: 플레이스홀더 → 실제 폼

## 안전성
- 쓰기 토큰은 Server Action(서버)에서만 사용 — 클라이언트 미노출
- `NOTION_*` 미설정 시 폼은 보이되 제출은 명확한 에러로 실패 — 로컬 `next build` 통과
- 미인증 접근은 미들웨어가 차단 + 액션에서 세션 재확인(이중)

## 병합 후 활성화 (배포자)
- Notion 통합에 **Insert content** 권한 부여
- 블로그 DB(#29 스키마)·프로젝트 DB 를 통합에 공유
- 프로젝트 `status` 는 DB 의 status 옵션명과 일치해야 함(없으면 비워두기)

## 후속
- PR-D: 공개 문의 폼 → Notion Inquiries DB + `/admin` 문의 목록