### PR TITLE
feat(contact): 공개 문의 폼 → Notion + /admin 문의 목록 (PR-D)

### DIFF
--- a/app/(site)/contact/actions.ts
+++ b/app/(site)/contact/actions.ts
@@ -1,0 +1,37 @@
+"use server"
+
+import { createInquiry, INQUIRY_TYPES } from "../../../lib/inquiries"
+
+export interface ContactState {
+  ok: boolean
+  message: string
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export async function submitInquiry(
+  _prev: ContactState,
+  formData: FormData
+): Promise<ContactState> {
+  // 허니팟: 봇이 채우는 숨은 필드. 값이 있으면 조용히 성공 처리(스팸 차단).
+  if (String(formData.get("company") || "").trim()) {
+    return { ok: true, message: "문의가 접수되었습니다. 감사합니다." }
+  }
+
+  const name = String(formData.get("name") || "").trim()
+  const email = String(formData.get("email") || "").trim()
+  const type = String(formData.get("type") || "").trim()
+  const message = String(formData.get("message") || "").trim()
+
+  if (!name) return { ok: false, message: "이름을 입력해주세요." }
+  if (!EMAIL_RE.test(email)) return { ok: false, message: "올바른 이메일 형식이 아닙니다." }
+  if (!message) return { ok: false, message: "메시지를 입력해주세요." }
+  const safeType = (INQUIRY_TYPES as readonly string[]).includes(type) ? type : INQUIRY_TYPES[0]
+
+  try {
+    await createInquiry({ name, email, type: safeType, message })
+    return { ok: true, message: "문의가 접수되었습니다. 확인 후 회신드리겠습니다." }
+  } catch (e) {
+    return { ok: false, message: (e as Error).message }
+  }
+}

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -1,0 +1,18 @@
+import ContactForm from "../../../components/contact/contactForm"
+
+export const metadata = { title: "Contact" }
+
+export default function Contact() {
+  return (
+    <div className="max-w-[640px]">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Contact</p>
+      <h1 className="mt-3 text-3xl font-bold tracking-tight text-fg sm:text-4xl">
+        연락하기
+      </h1>
+      <p className="mt-3 text-[15px] leading-relaxed text-muted">
+        협업·채용·면접 요청 등 무엇이든 편하게 남겨주세요. 이메일로 확인 후 회신드립니다.
+      </p>
+      <ContactForm />
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { auth, signOut } from "@/auth"
 import AdminForms from "../../components/admin/adminForms"
+import { getInquiries } from "../../lib/inquiries"
 
 // 검색엔진 비노출(민감 관리 페이지). 미들웨어가 접근 자체를 인증으로 막지만,
 // 색인/링크 노출도 이중으로 차단한다.
@@ -15,6 +16,7 @@ export const dynamic = "force-dynamic"
 export default async function AdminPage() {
   const session = await auth()
   const name = session?.user?.name ?? "관리자"
+  const inquiries = await getInquiries()
 
   return (
     <main className="mx-auto max-w-[720px] px-6 py-16">
@@ -25,6 +27,38 @@ export default async function AdminPage() {
       </p>
 
       <AdminForms />
+
+      {/* 접수된 문의 목록 */}
+      <section className="mt-14">
+        <h2 className="text-lg font-semibold text-fg">
+          문의 <span className="font-mono text-sm text-muted">({inquiries.length})</span>
+        </h2>
+        {inquiries.length === 0 ? (
+          <p className="mt-3 text-sm text-muted">
+            아직 접수된 문의가 없습니다. (NOTION_INQUIRIES_DB 미설정 시에도 비어 있음)
+          </p>
+        ) : (
+          <ul className="mt-4 divide-y divide-line">
+            {inquiries.map((q) => (
+              <li key={q.id} className="py-4">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-semibold text-fg">{q.name || "이름 없음"}</span>
+                    {q.type && <span className="chip">{q.type}</span>}
+                  </div>
+                  <time className="font-mono text-xs text-muted">{q.createdTime.slice(0, 10)}</time>
+                </div>
+                {q.email && (
+                  <a href={`mailto:${q.email}`} className="mt-1 block font-mono text-xs text-accent hover:underline">
+                    {q.email}
+                  </a>
+                )}
+                {q.message && <p className="mt-2 whitespace-pre-wrap text-sm text-muted">{q.message}</p>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
 
       <form
         action={async () => {

--- a/components/contact/contactForm.tsx
+++ b/components/contact/contactForm.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useActionState } from "react"
+import { submitInquiry, type ContactState } from "../../app/(site)/contact/actions"
+
+const INIT: ContactState = { ok: false, message: "" }
+
+// UI 옵션(서버 액션이 INQUIRY_TYPES 로 재검증). 서버 모듈을 client 로 끌어오지 않도록 여기서 정의.
+const TYPES = ["이메일 요청", "면접 요청"] as const
+
+const fieldCls =
+  "mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-fg outline-none focus-visible:ring-2 focus-visible:ring-accent"
+const labelCls = "block text-xs font-medium uppercase tracking-wide text-muted"
+
+export default function ContactForm() {
+  const [state, action, pending] = useActionState(submitInquiry, INIT)
+
+  return (
+    <form action={action} className="mt-8 grid gap-4">
+      {/* honeypot: 사람에겐 숨김, 봇이 채우면 스팸으로 처리 */}
+      <div className="absolute -left-[9999px]" aria-hidden="true">
+        <label>
+          회사
+          <input type="text" name="company" tabIndex={-1} autoComplete="off" />
+        </label>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block">
+          <span className={labelCls}>이름 *</span>
+          <input type="text" name="name" required className={fieldCls} placeholder="성함" />
+        </label>
+        <label className="block">
+          <span className={labelCls}>이메일 *</span>
+          <input type="email" name="email" required className={fieldCls} placeholder="you@example.com" />
+        </label>
+      </div>
+
+      <label className="block">
+        <span className={labelCls}>문의 유형</span>
+        <select name="type" className={fieldCls} defaultValue={TYPES[0]}>
+          {TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block">
+        <span className={labelCls}>메시지 *</span>
+        <textarea name="message" rows={6} required className={fieldCls} placeholder="문의 내용을 남겨주세요." />
+      </label>
+
+      <div>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-accent px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {pending ? "보내는 중…" : "문의 보내기"}
+        </button>
+      </div>
+
+      {state.message && (
+        <p
+          className={`rounded-md px-3 py-2 text-sm ${
+            state.ok ? "bg-accent/10 text-accent" : "border border-line text-muted"
+          }`}
+          role="status"
+        >
+          {state.message}
+        </p>
+      )}
+    </form>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -8,6 +8,7 @@ const nav = [
   { href: "/", label: "HOME" },
   { href: "/projects", label: "PROJECTS" },
   { href: "/blog", label: "BLOG" },
+  { href: "/contact", label: "CONTACT" },
 ]
 
 export default function Footer() {

--- a/config/index.ts
+++ b/config/index.ts
@@ -3,3 +3,6 @@ export const TOKEN = process.env.NOTION_TOKEN
 
 // 블로그 콘텐츠용 Notion 데이터베이스 (PR-B: 읽기 / PR-C: 쓰기)
 export const BLOG_DATABASE_ID = process.env.NOTION_BLOG_DB
+
+// 공개 문의(이메일·면접 요청) 저장용 Notion 데이터베이스 (PR-D)
+export const INQUIRIES_DATABASE_ID = process.env.NOTION_INQUIRIES_DB

--- a/lib/inquiries.ts
+++ b/lib/inquiries.ts
@@ -1,0 +1,119 @@
+// 공개 문의(이메일·면접 요청) 저장/조회. 서버에서만 호출한다.
+import { TOKEN, INQUIRIES_DATABASE_ID } from "../config"
+
+const NOTION_API = "https://api.notion.com/v1"
+const NOTION_VERSION = "2022-06-28"
+
+// Inquiries DB 속성명 (사용자 생성 DB 와 일치해야 함)
+export const INQUIRY_PROPS = {
+  name: "Name",
+  email: "Email",
+  type: "Type",
+  message: "Message",
+} as const
+
+// 문의 유형 (select 옵션명)
+export const INQUIRY_TYPES = ["이메일 요청", "면접 요청"] as const
+export type InquiryType = (typeof INQUIRY_TYPES)[number]
+
+function headers() {
+  return {
+    accept: "application/json",
+    "Notion-Version": NOTION_VERSION,
+    "content-type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  }
+}
+
+function rich(content: string) {
+  const text = content ?? ""
+  if (!text) return []
+  const chunks: string[] = []
+  for (let i = 0; i < text.length; i += 2000) chunks.push(text.slice(i, i + 2000))
+  return chunks.map((c) => ({ type: "text", text: { content: c } }))
+}
+
+export interface InquiryInput {
+  name: string
+  email: string
+  type: string
+  message: string
+}
+
+export async function createInquiry(input: InquiryInput): Promise<{ id: string }> {
+  if (!TOKEN || !INQUIRIES_DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_INQUIRIES_DB 미설정")
+
+  const properties: Record<string, unknown> = {
+    [INQUIRY_PROPS.name]: { title: rich(input.name) },
+    [INQUIRY_PROPS.email]: { email: input.email },
+    [INQUIRY_PROPS.message]: { rich_text: rich(input.message) },
+  }
+  if (input.type) properties[INQUIRY_PROPS.type] = { select: { name: input.type } }
+
+  const res = await fetch(`${NOTION_API}/pages`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify({ parent: { database_id: INQUIRIES_DATABASE_ID }, properties }),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "")
+    throw new Error(`문의 저장 실패 (${res.status}): ${detail.slice(0, 300)}`)
+  }
+  return (await res.json()) as { id: string }
+}
+
+export interface Inquiry {
+  id: string
+  name: string
+  email: string
+  type: string
+  message: string
+  createdTime: string
+}
+
+interface NotionRichText {
+  plain_text?: string
+}
+interface NotionPage {
+  id: string
+  created_time?: string
+  properties?: Record<string, unknown>
+}
+
+function plain(rt?: NotionRichText[]): string {
+  return (rt || []).map((t) => t.plain_text ?? "").join("")
+}
+
+// 관리자 목록용. 미설정/실패 시 빈 배열(관리자 페이지에서 빈 상태 안내).
+export async function getInquiries(): Promise<Inquiry[]> {
+  if (!TOKEN || !INQUIRIES_DATABASE_ID) return []
+
+  try {
+    const res = await fetch(`${NOTION_API}/databases/${INQUIRIES_DATABASE_ID}/query`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        sorts: [{ timestamp: "created_time", direction: "descending" }],
+        page_size: 100,
+      }),
+      cache: "no-store",
+    })
+    if (!res.ok) throw new Error(`Notion API ${res.status}`)
+    const json = (await res.json()) as { results?: NotionPage[] }
+
+    return (json.results || []).map((page) => {
+      const p = (name: string) => page.properties?.[name] as Record<string, unknown> | undefined
+      return {
+        id: page.id,
+        name: plain(p(INQUIRY_PROPS.name)?.title as NotionRichText[] | undefined),
+        email: (p(INQUIRY_PROPS.email)?.email as string) ?? "",
+        type: ((p(INQUIRY_PROPS.type)?.select as { name?: string } | undefined)?.name) ?? "",
+        message: plain(p(INQUIRY_PROPS.message)?.rich_text as NotionRichText[] | undefined),
+        createdTime: page.created_time ?? "",
+      }
+    })
+  } catch (e) {
+    console.error("[inquiries] Notion fetch failed:", (e as Error).message)
+    return []
+  }
+}


### PR DESCRIPTION
## 요약
방문자가 **이메일·면접 요청**을 남기는 공개 `/contact` 폼을 추가하고, 제출을 **Notion Inquiries DB** 에 저장한다. `/admin` 에서 접수 목록을 확인한다.

Closes #32

> ⚠️ **PR-C(#31) 위에 스택** (base `feat/30-admin-write`). PR-B → PR-C → 이 PR 순서로 병합하세요. 앞 PR이 dev 로 병합되면 base 가 자동 재지정됩니다.

## 변경
- `app/(site)/contact/page.tsx` + `components/contact/contactForm.tsx`: 공개 폼(이름·이메일·유형·메시지)
- `app/(site)/contact/actions.ts`: Server Action — **허니팟 스팸 차단** + 이메일 형식 검증 + 유형 화이트리스트
- `lib/inquiries.ts`: `createInquiry`(쓰기)/`getInquiries`(관리자 읽기), `INQUIRY_PROPS`/`INQUIRY_TYPES`
- `app/admin/page.tsx`: 하단에 **접수 문의 목록**(최신순, mailto 링크, 빈 상태 안내)
- `components/footer.tsx`: `CONTACT` 링크
- `config`: `INQUIRIES_DATABASE_ID`

## 안전성
- 저장 토큰은 Server Action(서버)에서만 — 클라이언트 미노출
- 공개 폼: 허니팟 + 서버측 검증. `NOTION_INQUIRIES_DB` 미설정 시 제출 실패·목록 빈 상태 — 로컬 `next build` 통과

## 병합 후 활성화 (배포자)
1. Notion Inquiries DB 생성: **Name**(title)·**Email**(email)·**Type**(select: 이메일 요청/면접 요청)·**Message**(rich_text)
2. 통합에 DB 공유(읽기+Insert content) → `NOTION_INQUIRIES_DB` env