### PR TITLE
fix: 관리자 쓰기·공개 문의 코드를 dev 로 재통합

### DIFF
--- a/app/(site)/contact/actions.ts
+++ b/app/(site)/contact/actions.ts
@@ -1,0 +1,37 @@
+"use server"
+
+import { createInquiry, INQUIRY_TYPES } from "../../../lib/inquiries"
+
+export interface ContactState {
+  ok: boolean
+  message: string
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export async function submitInquiry(
+  _prev: ContactState,
+  formData: FormData
+): Promise<ContactState> {
+  // 허니팟: 봇이 채우는 숨은 필드. 값이 있으면 조용히 성공 처리(스팸 차단).
+  if (String(formData.get("company") || "").trim()) {
+    return { ok: true, message: "문의가 접수되었습니다. 감사합니다." }
+  }
+
+  const name = String(formData.get("name") || "").trim()
+  const email = String(formData.get("email") || "").trim()
+  const type = String(formData.get("type") || "").trim()
+  const message = String(formData.get("message") || "").trim()
+
+  if (!name) return { ok: false, message: "이름을 입력해주세요." }
+  if (!EMAIL_RE.test(email)) return { ok: false, message: "올바른 이메일 형식이 아닙니다." }
+  if (!message) return { ok: false, message: "메시지를 입력해주세요." }
+  const safeType = (INQUIRY_TYPES as readonly string[]).includes(type) ? type : INQUIRY_TYPES[0]
+
+  try {
+    await createInquiry({ name, email, type: safeType, message })
+    return { ok: true, message: "문의가 접수되었습니다. 확인 후 회신드리겠습니다." }
+  } catch (e) {
+    return { ok: false, message: (e as Error).message }
+  }
+}

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -1,0 +1,18 @@
+import ContactForm from "../../../components/contact/contactForm"
+
+export const metadata = { title: "Contact" }
+
+export default function Contact() {
+  return (
+    <div className="max-w-[640px]">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Contact</p>
+      <h1 className="mt-3 text-3xl font-bold tracking-tight text-fg sm:text-4xl">
+        연락하기
+      </h1>
+      <p className="mt-3 text-[15px] leading-relaxed text-muted">
+        협업·채용·면접 요청 등 무엇이든 편하게 남겨주세요. 이메일로 확인 후 회신드립니다.
+      </p>
+      <ContactForm />
+    </div>
+  )
+}

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,0 +1,88 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { auth } from "@/auth"
+import { createBlogPage, createProjectPage } from "../../lib/notionWrite"
+
+export interface ActionState {
+  ok: boolean
+  message: string
+}
+
+function parseTags(raw: string): string[] {
+  return (raw || "")
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean)
+}
+
+function slugify(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w가-힣]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+// 모든 쓰기 액션은 세션을 재확인한다(미들웨어에 더해 방어).
+async function requireOwner(): Promise<string | null> {
+  const session = await auth()
+  return session?.user ? null : "인증이 필요합니다. 다시 로그인하세요."
+}
+
+export async function submitBlog(
+  _prev: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const authError = await requireOwner()
+  if (authError) return { ok: false, message: authError }
+
+  const title = String(formData.get("title") || "").trim()
+  if (!title) return { ok: false, message: "제목은 필수입니다." }
+
+  try {
+    await createBlogPage({
+      title,
+      slug: String(formData.get("slug") || "").trim() || slugify(title),
+      date: String(formData.get("date") || "").trim(),
+      category: String(formData.get("category") || "").trim(),
+      tags: parseTags(String(formData.get("tags") || "")),
+      summary: String(formData.get("summary") || "").trim(),
+      body: String(formData.get("body") || ""),
+      published: formData.get("published") === "on",
+    })
+    revalidatePath("/blog")
+    revalidatePath("/")
+    return { ok: true, message: `“${title}” 글을 Notion 에 등록했습니다.` }
+  } catch (e) {
+    return { ok: false, message: (e as Error).message }
+  }
+}
+
+export async function submitProject(
+  _prev: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  const authError = await requireOwner()
+  if (authError) return { ok: false, message: authError }
+
+  const name = String(formData.get("name") || "").trim()
+  if (!name) return { ok: false, message: "프로젝트명은 필수입니다." }
+
+  try {
+    await createProjectPage({
+      name,
+      description: String(formData.get("description") || "").trim(),
+      tags: parseTags(String(formData.get("tags") || "")),
+      github: String(formData.get("github") || "").trim(),
+      startDate: String(formData.get("startDate") || "").trim(),
+      endDate: String(formData.get("endDate") || "").trim(),
+      status: String(formData.get("status") || "").trim(),
+    })
+    revalidatePath("/projects")
+    revalidatePath("/")
+    return { ok: true, message: `“${name}” 프로젝트를 Notion 에 등록했습니다.` }
+  } catch (e) {
+    return { ok: false, message: (e as Error).message }
+  }
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { auth, signOut } from "@/auth"
+import AdminForms from "../../components/admin/adminForms"
 
 // 검색엔진 비노출(민감 관리 페이지). 미들웨어가 접근 자체를 인증으로 막지만,
 // 색인/링크 노출도 이중으로 차단한다.
@@ -20,15 +21,10 @@ export default async function AdminPage() {
       <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Admin</p>
       <h1 className="mt-3 text-2xl font-semibold text-fg">콘텐츠 관리</h1>
       <p className="mt-2 text-sm text-muted">
-        {name}님으로 로그인됨. 블로그·프로젝트·문의 관리는 다음 단계에서 추가됩니다.
+        {name}님으로 로그인됨. 블로그·프로젝트를 Notion 에 직접 등록할 수 있습니다.
       </p>
 
-      {/* 후속 PR에서 채워질 자리 (PR-C: 쓰기 폼 / PR-D: 문의 목록) */}
-      <div className="mt-8 grid gap-3">
-        <div className="card p-5 text-sm text-muted">블로그 작성 · 목록 <span className="text-xs">(예정 — PR-C)</span></div>
-        <div className="card p-5 text-sm text-muted">프로젝트 등록 · 목록 <span className="text-xs">(예정 — PR-C)</span></div>
-        <div className="card p-5 text-sm text-muted">문의(이메일·면접 요청) 확인 <span className="text-xs">(예정 — PR-D)</span></div>
-      </div>
+      <AdminForms />
 
       <form
         action={async () => {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { auth, signOut } from "@/auth"
 import AdminForms from "../../components/admin/adminForms"
+import { getInquiries } from "../../lib/inquiries"
 
 // 검색엔진 비노출(민감 관리 페이지). 미들웨어가 접근 자체를 인증으로 막지만,
 // 색인/링크 노출도 이중으로 차단한다.
@@ -15,6 +16,7 @@ export const dynamic = "force-dynamic"
 export default async function AdminPage() {
   const session = await auth()
   const name = session?.user?.name ?? "관리자"
+  const inquiries = await getInquiries()
 
   return (
     <main className="mx-auto max-w-[720px] px-6 py-16">
@@ -25,6 +27,38 @@ export default async function AdminPage() {
       </p>
 
       <AdminForms />
+
+      {/* 접수된 문의 목록 */}
+      <section className="mt-14">
+        <h2 className="text-lg font-semibold text-fg">
+          문의 <span className="font-mono text-sm text-muted">({inquiries.length})</span>
+        </h2>
+        {inquiries.length === 0 ? (
+          <p className="mt-3 text-sm text-muted">
+            아직 접수된 문의가 없습니다. (NOTION_INQUIRIES_DB 미설정 시에도 비어 있음)
+          </p>
+        ) : (
+          <ul className="mt-4 divide-y divide-line">
+            {inquiries.map((q) => (
+              <li key={q.id} className="py-4">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-semibold text-fg">{q.name || "이름 없음"}</span>
+                    {q.type && <span className="chip">{q.type}</span>}
+                  </div>
+                  <time className="font-mono text-xs text-muted">{q.createdTime.slice(0, 10)}</time>
+                </div>
+                {q.email && (
+                  <a href={`mailto:${q.email}`} className="mt-1 block font-mono text-xs text-accent hover:underline">
+                    {q.email}
+                  </a>
+                )}
+                {q.message && <p className="mt-2 whitespace-pre-wrap text-sm text-muted">{q.message}</p>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
 
       <form
         action={async () => {

--- a/components/admin/adminForms.tsx
+++ b/components/admin/adminForms.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useActionState, useState } from "react"
+import { submitBlog, submitProject, type ActionState } from "../../app/admin/actions"
+
+const INIT: ActionState = { ok: false, message: "" }
+
+const fieldCls =
+  "mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-fg outline-none focus-visible:ring-2 focus-visible:ring-accent"
+const labelCls = "block text-xs font-medium uppercase tracking-wide text-muted"
+
+function Field({
+  label,
+  name,
+  type = "text",
+  placeholder,
+  required,
+}: {
+  label: string
+  name: string
+  type?: string
+  placeholder?: string
+  required?: boolean
+}) {
+  return (
+    <label className="block">
+      <span className={labelCls}>
+        {label}
+        {required && <span className="text-accent"> *</span>}
+      </span>
+      <input type={type} name={name} placeholder={placeholder} required={required} className={fieldCls} />
+    </label>
+  )
+}
+
+function Status({ state }: { state: ActionState }) {
+  if (!state.message) return null
+  return (
+    <p
+      className={`mt-3 rounded-md px-3 py-2 text-sm ${
+        state.ok
+          ? "bg-accent/10 text-accent"
+          : "border border-line text-muted"
+      }`}
+      role="status"
+    >
+      {state.message}
+    </p>
+  )
+}
+
+function BlogForm() {
+  const [state, action, pending] = useActionState(submitBlog, INIT)
+  return (
+    <form action={action} className="grid gap-4">
+      <Field label="제목" name="title" placeholder="글 제목" required />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="Slug" name="slug" placeholder="비우면 제목에서 생성" />
+        <Field label="날짜" name="date" type="date" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="카테고리" name="category" placeholder="Performance / Backend …" />
+        <Field label="태그 (쉼표로 구분)" name="tags" placeholder="EF Core, C#" />
+      </div>
+      <label className="block">
+        <span className={labelCls}>요약</span>
+        <textarea name="summary" rows={2} className={fieldCls} placeholder="목록에 보일 한두 문장" />
+      </label>
+      <label className="block">
+        <span className={labelCls}>본문 (마크다운 유사: # 제목, ``` 코드, - 목록)</span>
+        <textarea name="body" rows={12} className={`${fieldCls} font-mono`} placeholder={"## 소제목\n문단 내용...\n\n- 목록 항목\n\n```\n코드\n```"} />
+      </label>
+      <label className="flex items-center gap-2 text-sm text-fg">
+        <input type="checkbox" name="published" defaultChecked className="h-4 w-4 rounded border-line" />
+        바로 발행 (Published)
+      </label>
+      <div>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {pending ? "등록 중…" : "블로그 글 등록"}
+        </button>
+      </div>
+      <Status state={state} />
+    </form>
+  )
+}
+
+function ProjectForm() {
+  const [state, action, pending] = useActionState(submitProject, INIT)
+  return (
+    <form action={action} className="grid gap-4">
+      <Field label="프로젝트명" name="name" placeholder="프로젝트 이름" required />
+      <label className="block">
+        <span className={labelCls}>설명</span>
+        <textarea name="description" rows={3} className={fieldCls} placeholder="한두 문장 요약" />
+      </label>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="태그 (쉼표로 구분)" name="tags" placeholder="C#, Azure" />
+        <Field label="GitHub / 링크" name="github" placeholder="https://github.com/…" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Field label="시작일" name="startDate" type="date" />
+        <Field label="종료일" name="endDate" type="date" />
+        <Field label="상태 (status 옵션명)" name="status" placeholder="Done" />
+      </div>
+      <div>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {pending ? "등록 중…" : "프로젝트 등록"}
+        </button>
+      </div>
+      <Status state={state} />
+    </form>
+  )
+}
+
+export default function AdminForms() {
+  const [tab, setTab] = useState<"blog" | "project">("blog")
+  return (
+    <div className="mt-8">
+      <div className="mb-6 flex gap-2 border-b border-line pb-3">
+        {(["blog", "project"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+              tab === t ? "bg-accent text-white" : "border border-line text-muted hover:bg-surface hover:text-fg"
+            }`}
+          >
+            {t === "blog" ? "블로그" : "프로젝트"}
+          </button>
+        ))}
+      </div>
+      {tab === "blog" ? <BlogForm /> : <ProjectForm />}
+    </div>
+  )
+}

--- a/components/contact/contactForm.tsx
+++ b/components/contact/contactForm.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useActionState } from "react"
+import { submitInquiry, type ContactState } from "../../app/(site)/contact/actions"
+
+const INIT: ContactState = { ok: false, message: "" }
+
+// UI 옵션(서버 액션이 INQUIRY_TYPES 로 재검증). 서버 모듈을 client 로 끌어오지 않도록 여기서 정의.
+const TYPES = ["이메일 요청", "면접 요청"] as const
+
+const fieldCls =
+  "mt-1 w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-fg outline-none focus-visible:ring-2 focus-visible:ring-accent"
+const labelCls = "block text-xs font-medium uppercase tracking-wide text-muted"
+
+export default function ContactForm() {
+  const [state, action, pending] = useActionState(submitInquiry, INIT)
+
+  return (
+    <form action={action} className="mt-8 grid gap-4">
+      {/* honeypot: 사람에겐 숨김, 봇이 채우면 스팸으로 처리 */}
+      <div className="absolute -left-[9999px]" aria-hidden="true">
+        <label>
+          회사
+          <input type="text" name="company" tabIndex={-1} autoComplete="off" />
+        </label>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block">
+          <span className={labelCls}>이름 *</span>
+          <input type="text" name="name" required className={fieldCls} placeholder="성함" />
+        </label>
+        <label className="block">
+          <span className={labelCls}>이메일 *</span>
+          <input type="email" name="email" required className={fieldCls} placeholder="you@example.com" />
+        </label>
+      </div>
+
+      <label className="block">
+        <span className={labelCls}>문의 유형</span>
+        <select name="type" className={fieldCls} defaultValue={TYPES[0]}>
+          {TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block">
+        <span className={labelCls}>메시지 *</span>
+        <textarea name="message" rows={6} required className={fieldCls} placeholder="문의 내용을 남겨주세요." />
+      </label>
+
+      <div>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md bg-accent px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+        >
+          {pending ? "보내는 중…" : "문의 보내기"}
+        </button>
+      </div>
+
+      {state.message && (
+        <p
+          className={`rounded-md px-3 py-2 text-sm ${
+            state.ok ? "bg-accent/10 text-accent" : "border border-line text-muted"
+          }`}
+          role="status"
+        >
+          {state.message}
+        </p>
+      )}
+    </form>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -8,6 +8,7 @@ const nav = [
   { href: "/", label: "HOME" },
   { href: "/projects", label: "PROJECTS" },
   { href: "/blog", label: "BLOG" },
+  { href: "/contact", label: "CONTACT" },
 ]
 
 export default function Footer() {

--- a/config/index.ts
+++ b/config/index.ts
@@ -3,3 +3,6 @@ export const TOKEN = process.env.NOTION_TOKEN
 
 // 블로그 콘텐츠용 Notion 데이터베이스 (PR-B: 읽기 / PR-C: 쓰기)
 export const BLOG_DATABASE_ID = process.env.NOTION_BLOG_DB
+
+// 공개 문의(이메일·면접 요청) 저장용 Notion 데이터베이스 (PR-D)
+export const INQUIRIES_DATABASE_ID = process.env.NOTION_INQUIRIES_DB

--- a/lib/inquiries.ts
+++ b/lib/inquiries.ts
@@ -1,0 +1,119 @@
+// 공개 문의(이메일·면접 요청) 저장/조회. 서버에서만 호출한다.
+import { TOKEN, INQUIRIES_DATABASE_ID } from "../config"
+
+const NOTION_API = "https://api.notion.com/v1"
+const NOTION_VERSION = "2022-06-28"
+
+// Inquiries DB 속성명 (사용자 생성 DB 와 일치해야 함)
+export const INQUIRY_PROPS = {
+  name: "Name",
+  email: "Email",
+  type: "Type",
+  message: "Message",
+} as const
+
+// 문의 유형 (select 옵션명)
+export const INQUIRY_TYPES = ["이메일 요청", "면접 요청"] as const
+export type InquiryType = (typeof INQUIRY_TYPES)[number]
+
+function headers() {
+  return {
+    accept: "application/json",
+    "Notion-Version": NOTION_VERSION,
+    "content-type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  }
+}
+
+function rich(content: string) {
+  const text = content ?? ""
+  if (!text) return []
+  const chunks: string[] = []
+  for (let i = 0; i < text.length; i += 2000) chunks.push(text.slice(i, i + 2000))
+  return chunks.map((c) => ({ type: "text", text: { content: c } }))
+}
+
+export interface InquiryInput {
+  name: string
+  email: string
+  type: string
+  message: string
+}
+
+export async function createInquiry(input: InquiryInput): Promise<{ id: string }> {
+  if (!TOKEN || !INQUIRIES_DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_INQUIRIES_DB 미설정")
+
+  const properties: Record<string, unknown> = {
+    [INQUIRY_PROPS.name]: { title: rich(input.name) },
+    [INQUIRY_PROPS.email]: { email: input.email },
+    [INQUIRY_PROPS.message]: { rich_text: rich(input.message) },
+  }
+  if (input.type) properties[INQUIRY_PROPS.type] = { select: { name: input.type } }
+
+  const res = await fetch(`${NOTION_API}/pages`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify({ parent: { database_id: INQUIRIES_DATABASE_ID }, properties }),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "")
+    throw new Error(`문의 저장 실패 (${res.status}): ${detail.slice(0, 300)}`)
+  }
+  return (await res.json()) as { id: string }
+}
+
+export interface Inquiry {
+  id: string
+  name: string
+  email: string
+  type: string
+  message: string
+  createdTime: string
+}
+
+interface NotionRichText {
+  plain_text?: string
+}
+interface NotionPage {
+  id: string
+  created_time?: string
+  properties?: Record<string, unknown>
+}
+
+function plain(rt?: NotionRichText[]): string {
+  return (rt || []).map((t) => t.plain_text ?? "").join("")
+}
+
+// 관리자 목록용. 미설정/실패 시 빈 배열(관리자 페이지에서 빈 상태 안내).
+export async function getInquiries(): Promise<Inquiry[]> {
+  if (!TOKEN || !INQUIRIES_DATABASE_ID) return []
+
+  try {
+    const res = await fetch(`${NOTION_API}/databases/${INQUIRIES_DATABASE_ID}/query`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        sorts: [{ timestamp: "created_time", direction: "descending" }],
+        page_size: 100,
+      }),
+      cache: "no-store",
+    })
+    if (!res.ok) throw new Error(`Notion API ${res.status}`)
+    const json = (await res.json()) as { results?: NotionPage[] }
+
+    return (json.results || []).map((page) => {
+      const p = (name: string) => page.properties?.[name] as Record<string, unknown> | undefined
+      return {
+        id: page.id,
+        name: plain(p(INQUIRY_PROPS.name)?.title as NotionRichText[] | undefined),
+        email: (p(INQUIRY_PROPS.email)?.email as string) ?? "",
+        type: ((p(INQUIRY_PROPS.type)?.select as { name?: string } | undefined)?.name) ?? "",
+        message: plain(p(INQUIRY_PROPS.message)?.rich_text as NotionRichText[] | undefined),
+        createdTime: page.created_time ?? "",
+      }
+    })
+  } catch (e) {
+    console.error("[inquiries] Notion fetch failed:", (e as Error).message)
+    return []
+  }
+}

--- a/lib/notionWrite.ts
+++ b/lib/notionWrite.ts
@@ -1,0 +1,170 @@
+// Notion 쓰기(페이지 생성) 헬퍼. 서버(Server Action)에서만 호출한다.
+// 읽기(lib/postsData.ts, lib/notion.ts)와 동일한 REST API·속성명을 재사용한다.
+import { TOKEN, DATABASE_ID, BLOG_DATABASE_ID } from "../config"
+import { BLOG_PROPS } from "./postsData"
+
+const NOTION_API = "https://api.notion.com/v1"
+const NOTION_VERSION = "2022-06-28"
+
+// 프로젝트 DB 속성명 (lib/notion.ts 읽기 매핑과 일치)
+export const PROJECT_PROPS = {
+  name: "projectName",
+  description: "description",
+  tags: "tag",
+  github: "github",
+  workPeriod: "workPeriod",
+  status: "status",
+} as const
+
+function headers() {
+  return {
+    accept: "application/json",
+    "Notion-Version": NOTION_VERSION,
+    "content-type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  }
+}
+
+// Notion rich_text 는 항목당 content 2000자 제한 → 안전하게 청크로 분할.
+function rich(content: string) {
+  const text = content ?? ""
+  if (!text) return []
+  const chunks: string[] = []
+  for (let i = 0; i < text.length; i += 2000) chunks.push(text.slice(i, i + 2000))
+  return chunks.map((c) => ({ type: "text", text: { content: c } }))
+}
+
+function block(type: string, content: string, extra: Record<string, unknown> = {}) {
+  return {
+    object: "block",
+    type,
+    [type]: { rich_text: rich(content), ...extra },
+  }
+}
+
+// 마크다운 유사 본문 텍스트 → Notion 블록 배열.
+// 지원: # / ## / ### 헤딩, ``` 코드펜스, - / * 목록, 그 외 문단(빈 줄로 분리).
+export function textToBlocks(src: string): Record<string, unknown>[] {
+  const lines = (src ?? "").replace(/\r\n/g, "\n").split("\n")
+  const blocks: Record<string, unknown>[] = []
+  let para: string[] = []
+  let inCode = false
+  let codeBuf: string[] = []
+
+  const flushPara = () => {
+    if (para.length) {
+      const t = para.join(" ").trim()
+      if (t) blocks.push(block("paragraph", t))
+      para = []
+    }
+  }
+
+  for (const line of lines) {
+    const fence = line.trim().startsWith("```")
+    if (fence) {
+      if (inCode) {
+        blocks.push(block("code", codeBuf.join("\n"), { language: "plain text" }))
+        codeBuf = []
+        inCode = false
+      } else {
+        flushPara()
+        inCode = true
+      }
+      continue
+    }
+    if (inCode) {
+      codeBuf.push(line)
+      continue
+    }
+
+    const h = line.match(/^(#{1,3})\s+(.*)$/)
+    const li = line.match(/^[-*]\s+(.*)$/)
+    if (h) {
+      flushPara()
+      const level = h[1].length
+      blocks.push(block(`heading_${level}`, h[2].trim()))
+    } else if (li) {
+      flushPara()
+      blocks.push(block("bulleted_list_item", li[1].trim()))
+    } else if (line.trim() === "") {
+      flushPara()
+    } else {
+      para.push(line.trim())
+    }
+  }
+  if (inCode && codeBuf.length) blocks.push(block("code", codeBuf.join("\n"), { language: "plain text" }))
+  flushPara()
+  return blocks
+}
+
+async function createPage(body: Record<string, unknown>) {
+  const res = await fetch(`${NOTION_API}/pages`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "")
+    throw new Error(`Notion 페이지 생성 실패 (${res.status}): ${detail.slice(0, 300)}`)
+  }
+  return (await res.json()) as { id: string }
+}
+
+export interface BlogInput {
+  title: string
+  slug: string
+  date: string
+  category: string
+  tags: string[]
+  summary: string
+  body: string
+  published: boolean
+}
+
+export async function createBlogPage(input: BlogInput): Promise<{ id: string }> {
+  if (!TOKEN || !BLOG_DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_BLOG_DB 미설정")
+
+  const properties: Record<string, unknown> = {
+    [BLOG_PROPS.title]: { title: rich(input.title) },
+    [BLOG_PROPS.slug]: { rich_text: rich(input.slug) },
+    [BLOG_PROPS.summary]: { rich_text: rich(input.summary) },
+    [BLOG_PROPS.tags]: { multi_select: input.tags.map((name) => ({ name })) },
+    [BLOG_PROPS.published]: { checkbox: input.published },
+  }
+  if (input.date) properties[BLOG_PROPS.date] = { date: { start: input.date } }
+  if (input.category) properties[BLOG_PROPS.category] = { select: { name: input.category } }
+
+  return createPage({
+    parent: { database_id: BLOG_DATABASE_ID },
+    properties,
+    children: textToBlocks(input.body),
+  })
+}
+
+export interface ProjectInput {
+  name: string
+  description: string
+  tags: string[]
+  github: string
+  startDate: string
+  endDate: string
+  status: string
+}
+
+export async function createProjectPage(input: ProjectInput): Promise<{ id: string }> {
+  if (!TOKEN || !DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_DB 미설정")
+
+  const properties: Record<string, unknown> = {
+    [PROJECT_PROPS.name]: { title: rich(input.name) },
+    [PROJECT_PROPS.description]: { rich_text: rich(input.description) },
+    [PROJECT_PROPS.tags]: { multi_select: input.tags.map((name) => ({ name })) },
+  }
+  if (input.github) properties[PROJECT_PROPS.github] = { url: input.github }
+  if (input.startDate)
+    properties[PROJECT_PROPS.workPeriod] = {
+      date: { start: input.startDate, end: input.endDate || null },
+    }
+  if (input.status) properties[PROJECT_PROPS.status] = { status: { name: input.status } }
+
+  return createPage({ parent: { database_id: DATABASE_ID }, properties })
+}


### PR DESCRIPTION
## 배경
스택 PR 병합 중 base 자동 재지정이 걸리지 않아, /admin 쓰기(#31)와 공개 문의 폼(#33) 코드가 dev 가 아닌 중간 피처 브랜치로 병합됐다. 이 코드를 dev 로 올린다.

Closes #35

## 내용
feat/30-admin-write(B+C+D 포함)를 dev 에 병합. dev 에 추가되는 것:
- feat(admin): /admin 블로그·프로젝트 Notion 등록 (기존 #31)
- feat(contact): 공개 /contact 폼 → Notion Inquiries + /admin 문의 목록 (기존 #33)

B(블로그 읽기)는 이미 dev 에 있어 중복 없음.

## 검증
각 변경은 병합 전 워크트리에서 next lint+next build 통과, 원 PR CI 그린. 이 PR CI 로 dev 기준 재확인.