### PR TITLE
fix(admin): 글 저장 504 해소 + 저장 UX(로딩·토스트·에러화면 방지)

### DIFF
--- a/app/admin/blog/[id]/edit/page.tsx
+++ b/app/admin/blog/[id]/edit/page.tsx
@@ -10,6 +10,8 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 }
 export const dynamic = "force-dynamic"
+// 본문 블록 교체(다건 Notion 호출)가 기본 10초를 넘을 수 있어 상향(플랜 허용 범위 내).
+export const maxDuration = 60
 
 export default async function EditBlogPost({
   params,

--- a/app/admin/blog/actions.ts
+++ b/app/admin/blog/actions.ts
@@ -1,7 +1,6 @@
 "use server"
 
 import { revalidatePath } from "next/cache"
-import { redirect } from "next/navigation"
 import {
   createBlogPage,
   updateBlogPage,
@@ -16,11 +15,9 @@ function revalidateBlog() {
   revalidatePath("/")
 }
 
-// 생성/수정 겸용. hidden id 가 있으면 수정, 없으면 생성. 성공 시 목록으로 이동.
-export async function saveBlogPost(
-  _prev: ActionState,
-  formData: FormData
-): Promise<ActionState> {
+// 생성/수정 겸용. hidden id 가 있으면 수정, 없으면 생성.
+// 이동은 클라이언트가 담당(성공/실패 UX·토스트 제어 위해 redirect 안 함).
+export async function saveBlogPost(formData: FormData): Promise<ActionState> {
   const authError = await requireOwner()
   if (authError) return { ok: false, message: authError }
 
@@ -40,15 +37,20 @@ export async function saveBlogPost(
   }
 
   try {
-    if (id) await updateBlogPage(id, input)
-    else await createBlogPage(input)
+    if (id) {
+      // 본문이 실제로 바뀐 경우에만 블록을 교체(다건 삭제·재생성). 아니면 속성만 갱신.
+      const originalBody = String(formData.get("originalBody") || "")
+      const bodyChanged = input.body !== originalBody
+      await updateBlogPage(id, input, bodyChanged)
+    } else {
+      await createBlogPage(input)
+    }
   } catch (e) {
     return { ok: false, message: (e as Error).message }
   }
 
-  // 성공: 캐시 무효화 후 목록으로 리다이렉트 (redirect 는 try 밖에서 — throw 로 동작).
   revalidateBlog()
-  redirect("/admin/blog")
+  return { ok: true, message: id ? "변경이 저장되었습니다." : "글이 등록되었습니다." }
 }
 
 export async function deleteBlogPost(id: string): Promise<void> {

--- a/app/admin/blog/new/page.tsx
+++ b/app/admin/blog/new/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 }
 export const dynamic = "force-dynamic"
+export const maxDuration = 60
 
 export default function NewBlogPost() {
   return (

--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+// /admin 세그먼트 에러 백스톱 — 예기치 못한 오류가 나도 전역 에러 화면 대신
+// 인라인 안내 + 재시도로 처리한다.
+export default function AdminError({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <main className="mx-auto max-w-[720px] px-6 py-16">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Admin</p>
+      <h1 className="mt-3 text-xl font-semibold text-fg">문제가 발생했어요</h1>
+      <p className="mt-2 text-sm text-muted">
+        요청 처리 중 오류가 났습니다. 다시 시도하거나 목록으로 돌아가세요.
+      </p>
+      <div className="mt-6 flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+        >
+          다시 시도
+        </button>
+        <a href="/admin/blog" className="link-underline text-sm text-muted">
+          블로그 목록으로
+        </a>
+      </div>
+    </main>
+  )
+}

--- a/components/admin/blogPostForm.tsx
+++ b/components/admin/blogPostForm.tsx
@@ -1,12 +1,11 @@
 "use client"
 
-import { useActionState } from "react"
+import { useState } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { saveBlogPost } from "../../app/admin/blog/actions"
-import { Field, Status, fieldCls, labelCls } from "./formFields"
-import type { ActionState } from "../../lib/adminForm"
-
-const INIT: ActionState = { ok: false, message: "" }
+import { Field, fieldCls, labelCls } from "./formFields"
+import { useToast } from "./toast"
 
 export interface BlogFormInitial {
   id?: string
@@ -21,54 +20,96 @@ export interface BlogFormInitial {
 }
 
 export default function BlogPostForm({ initial = {} }: { initial?: BlogFormInitial }) {
-  const [state, action, pending] = useActionState(saveBlogPost, INIT)
   const isEdit = Boolean(initial.id)
+  const router = useRouter()
+  const { show, node } = useToast()
+  const [saving, setSaving] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (saving) return
+    const formData = new FormData(e.currentTarget)
+    setSaving(true)
+    try {
+      const res = await saveBlogPost(formData)
+      if (res.ok) {
+        // 성공: 목록으로 이동 + 갱신. 입력값은 보존할 필요 없음(폼 이탈).
+        show("success", res.message)
+        router.push("/admin/blog")
+        router.refresh()
+        return // saving 유지(폼 언마운트)
+      }
+      // 검증/저장 실패: 토스트로 안내하고 폼에 머무름(입력 보존)
+      show("error", res.message || "저장에 실패했습니다.")
+    } catch {
+      // 타임아웃(504)·네트워크 오류 등 예외: 에러 화면 대신 토스트로 처리하고 폼 유지
+      show(
+        "error",
+        "저장에 실패했습니다. 시간 초과 또는 네트워크 오류일 수 있어요. 잠시 후 다시 시도해주세요."
+      )
+    }
+    setSaving(false)
+  }
 
   return (
-    <form action={action} className="grid gap-4">
-      {isEdit && <input type="hidden" name="id" value={initial.id} />}
+    <div className="relative">
+      <form onSubmit={handleSubmit} className="grid gap-4">
+        {isEdit && <input type="hidden" name="id" value={initial.id} />}
+        {isEdit && <input type="hidden" name="originalBody" value={initial.body ?? ""} />}
 
-      <Field label="제목" name="title" placeholder="글 제목" required defaultValue={initial.title} />
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Field label="Slug" name="slug" placeholder="비우면 제목에서 생성" defaultValue={initial.slug} />
-        <Field label="날짜" name="date" type="date" defaultValue={initial.date} />
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Field label="카테고리" name="category" placeholder="Performance / Backend …" defaultValue={initial.category} />
-        <Field label="태그 (쉼표로 구분)" name="tags" placeholder="EF Core, C#" defaultValue={initial.tags} />
-      </div>
-      <label className="block">
-        <span className={labelCls}>요약</span>
-        <textarea name="summary" rows={2} className={fieldCls} placeholder="목록에 보일 한두 문장" defaultValue={initial.summary} />
-      </label>
-      <label className="block">
-        <span className={labelCls}>본문 (마크다운 유사: # 제목, ``` 코드, - 목록)</span>
-        <textarea
-          name="body"
-          rows={14}
-          className={`${fieldCls} font-mono`}
-          placeholder={"## 소제목\n문단 내용...\n\n- 목록 항목\n\n```\n코드\n```"}
-          defaultValue={initial.body}
-        />
-      </label>
-      <label className="flex items-center gap-2 text-sm text-fg">
-        <input type="checkbox" name="published" defaultChecked={initial.published ?? true} className="h-4 w-4 rounded border-line" />
-        발행 (Published)
-      </label>
+        <Field label="제목" name="title" placeholder="글 제목" required defaultValue={initial.title} />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="Slug" name="slug" placeholder="비우면 제목에서 생성" defaultValue={initial.slug} />
+          <Field label="날짜" name="date" type="date" defaultValue={initial.date} />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="카테고리" name="category" placeholder="Performance / Backend …" defaultValue={initial.category} />
+          <Field label="태그 (쉼표로 구분)" name="tags" placeholder="EF Core, C#" defaultValue={initial.tags} />
+        </div>
+        <label className="block">
+          <span className={labelCls}>요약</span>
+          <textarea name="summary" rows={2} className={fieldCls} placeholder="목록에 보일 한두 문장" defaultValue={initial.summary} />
+        </label>
+        <label className="block">
+          <span className={labelCls}>본문 (마크다운 유사: # 제목, ``` 코드, - 목록)</span>
+          <textarea
+            name="body"
+            rows={14}
+            className={`${fieldCls} font-mono`}
+            placeholder={"## 소제목\n문단 내용...\n\n- 목록 항목\n\n```\n코드\n```"}
+            defaultValue={initial.body}
+          />
+        </label>
+        <label className="flex items-center gap-2 text-sm text-fg">
+          <input type="checkbox" name="published" defaultChecked={initial.published ?? true} className="h-4 w-4 rounded border-line" />
+          발행 (Published)
+        </label>
 
-      <div className="flex items-center gap-3">
-        <button
-          type="submit"
-          disabled={pending}
-          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
-        >
-          {pending ? "저장 중…" : isEdit ? "변경 저장" : "글 등록"}
-        </button>
-        <Link href="/admin/blog" className="link-underline text-sm text-muted">
-          취소
-        </Link>
-      </div>
-      <Status state={state} />
-    </form>
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+          >
+            {saving ? "저장 중…" : isEdit ? "변경 저장" : "글 등록"}
+          </button>
+          <Link href="/admin/blog" className="link-underline text-sm text-muted">
+            취소
+          </Link>
+        </div>
+      </form>
+
+      {/* 로딩 오버레이 — 저장 대기 중 폼을 덮고 스피너 표시 */}
+      {saving && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-page/70 backdrop-blur-[1px]">
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-line border-t-accent" />
+            저장 중…
+          </div>
+        </div>
+      )}
+
+      {node}
+    </div>
   )
 }

--- a/components/admin/blogRowActions.tsx
+++ b/components/admin/blogRowActions.tsx
@@ -1,8 +1,10 @@
 "use client"
 
-import { useTransition } from "react"
+import { useState } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { deleteBlogPost, togglePublish } from "../../app/admin/blog/actions"
+import { useToast } from "./toast"
 
 export default function BlogRowActions({
   id,
@@ -13,7 +15,22 @@ export default function BlogRowActions({
   title: string
   published: boolean
 }) {
-  const [pending, start] = useTransition()
+  const router = useRouter()
+  const { show, node } = useToast()
+  const [busy, setBusy] = useState(false)
+
+  async function run(fn: () => Promise<void>, successMsg: string) {
+    if (busy) return
+    setBusy(true)
+    try {
+      await fn()
+      show("success", successMsg)
+      router.refresh()
+    } catch {
+      show("error", "처리에 실패했습니다. 잠시 후 다시 시도해주세요.")
+    }
+    setBusy(false)
+  }
 
   return (
     <div className="flex items-center gap-3 text-xs">
@@ -22,24 +39,25 @@ export default function BlogRowActions({
       </Link>
       <button
         type="button"
-        disabled={pending}
-        onClick={() => start(() => togglePublish(id, !published))}
+        disabled={busy}
+        onClick={() => run(() => togglePublish(id, !published), published ? "비공개로 전환했습니다." : "발행했습니다.")}
         className="link-underline text-muted hover:text-accent disabled:opacity-50"
       >
         {published ? "비공개로" : "발행"}
       </button>
       <button
         type="button"
-        disabled={pending}
+        disabled={busy}
         onClick={() => {
           if (confirm(`“${title}”을(를) 삭제(아카이브)할까요? Notion 휴지통에서 복구할 수 있습니다.`)) {
-            start(() => deleteBlogPost(id))
+            run(() => deleteBlogPost(id), "삭제(아카이브)했습니다.")
           }
         }}
         className="link-underline text-muted hover:text-red-500 disabled:opacity-50"
       >
         삭제
       </button>
+      {node}
     </div>
   )
 }

--- a/components/admin/toast.tsx
+++ b/components/admin/toast.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { useCallback, useRef, useState } from "react"
+
+export type ToastType = "success" | "error"
+
+// 프로바이더 없이 쓰는 경량 토스트. { show, node } 를 반환하고
+// 컴포넌트는 반환된 node 를 렌더한다. 4초 뒤 자동 사라짐.
+export function useToast() {
+  const [toast, setToast] = useState<{ type: ToastType; msg: string } | null>(null)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const show = useCallback((type: ToastType, msg: string) => {
+    if (timer.current) clearTimeout(timer.current)
+    setToast({ type, msg })
+    timer.current = setTimeout(() => setToast(null), 4000)
+  }, [])
+
+  const node = toast ? (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed bottom-6 left-1/2 z-50 max-w-[90vw] -translate-x-1/2 rounded-md px-4 py-2.5 text-sm shadow-lg ${
+        toast.type === "success" ? "bg-accent text-white" : "bg-red-600 text-white"
+      }`}
+    >
+      {toast.msg}
+    </div>
+  ) : null
+
+  return { show, node }
+}

--- a/lib/notionWrite.ts
+++ b/lib/notionWrite.ts
@@ -146,8 +146,16 @@ async function replaceBody(pageId: string, bodyText: string) {
   if (!listRes.ok) throw new Error(`기존 블록 조회 실패 (${listRes.status})`)
   const list = (await listRes.json()) as { results?: { id: string }[] }
 
-  for (const b of list.results || []) {
-    await fetch(`${NOTION_API}/blocks/${b.id}`, { method: "DELETE", headers: headers() })
+  // 순차 삭제는 블록 수만큼 왕복이 쌓여 서버리스 10초 한계를 넘긴다(504).
+  // 동시성을 제한한 배치 병렬로 삭제해 왕복 지연을 상수 수준으로 낮춘다.
+  const ids = (list.results || []).map((b) => b.id)
+  const CONCURRENCY = 8
+  for (let i = 0; i < ids.length; i += CONCURRENCY) {
+    await Promise.all(
+      ids.slice(i, i + CONCURRENCY).map((id) =>
+        fetch(`${NOTION_API}/blocks/${id}`, { method: "DELETE", headers: headers() })
+      )
+    )
   }
 
   const children = textToBlocks(bodyText)
@@ -200,10 +208,16 @@ export async function createBlogPage(input: BlogInput): Promise<{ id: string }> 
   })
 }
 
-export async function updateBlogPage(id: string, input: BlogInput): Promise<{ id: string }> {
+// replaceBodyContent=false 면 속성만 갱신하고 본문 블록 교체를 건너뛴다.
+// 본문이 안 바뀐 수정(메타만 변경/재저장)에서 다건 블록 삭제·재생성을 피해 빠르게 저장.
+export async function updateBlogPage(
+  id: string,
+  input: BlogInput,
+  replaceBodyContent = true
+): Promise<{ id: string }> {
   if (!TOKEN || !BLOG_DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_BLOG_DB 미설정")
   await patchPage(id, { properties: blogProperties(input) })
-  await replaceBody(id, input.body)
+  if (replaceBodyContent) await replaceBody(id, input.body)
   return { id }
 }
 


### PR DESCRIPTION
## 배경
`/admin/blog/[id]/edit` 저장이 Vercel 10초 런타임 타임아웃(504)으로 실패하고 에러 화면으로 넘어감. 원인은 본문 교체가 기존 블록을 **하나씩 순차 DELETE**하던 것.

Closes #43

## 변경
### 타임아웃 해소
- `lib/notionWrite.replaceBody`: 순차 삭제 → **동시성 제한(8) 배치 병렬**
- `updateBlogPage(id, input, replaceBodyContent)`: **본문 미변경 시 블록 교체 skip**(속성만 PATCH). `saveBlogPost`가 `originalBody`와 비교 → 메타만 수정/재저장은 API 1회로 즉시
- 편집/작성 라우트 `maxDuration = 60`(본문 다건 교체 여유)

### 저장 UX (요청 사항)
- `blogPostForm`: `onSubmit` 핸들러 — 저장 중 **로딩 오버레이(스피너)**, 성공 시 목록 이동+refresh, **실패/타임아웃은 토스트로 안내하고 폼에 머무름(입력 보존)** — 에러 화면으로 안 넘어감
- `blogRowActions`(발행/삭제)도 try/catch + 토스트
- `components/admin/toast.tsx`(신규): 경량 토스트 훅
- `app/admin/error.tsx`(신규): `/admin` 세그먼트 에러 백스톱(전역 에러 화면 대신 인라인 + 재시도)

## 검증
- `next lint`+`next build` 통과
- 실제 Blog DB로 24블록 글 병렬 교체 타이밍 측정(로컬 WSL 기준 ~12s → Vercel 저지연에선 더 짧음; maxDuration=60 + 본문 미변경 skip으로 안전망 이중화)
- 병합·배포 후 편집 저장 재현 케이스(Security 글) 확인 권장

## 참고
- 본문 인라인 마크다운 렌더링(이슈 #42)은 별개 — 다음 작업