### PR TITLE
fix(blog): 본문 인라인 마크다운 렌더링 (코드·볼드·링크)

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { readingMinutes } from "../../../../lib/posts"
 import { getPosts, getPost, getAdjacent } from "../../../../lib/postsData"
 import CodeBlock from "../../../../components/blog/codeBlock"
 import Toc from "../../../../components/blog/toc"
+import { renderInline } from "../../../../components/blog/inlineMarkdown"
 
 interface TocItem {
   id: string
@@ -16,10 +17,10 @@ function Block({ block, index }: { block: BlockType; index: number }) {
   if (block.h)
     return (
       <h2 id={`h-${index}`} className="mt-10 mb-3 scroll-mt-24 text-2xl font-bold text-fg">
-        {block.h}
+        {renderInline(block.h)}
       </h2>
     )
-  if (block.p) return <p className="mt-4 text-[16px] leading-[1.8] text-muted">{block.p}</p>
+  if (block.p) return <p className="mt-4 text-[16px] leading-[1.8] text-muted">{renderInline(block.p)}</p>
   if (block.code) return <CodeBlock code={block.code} />
   if (block.ul)
     return (
@@ -29,7 +30,7 @@ function Block({ block, index }: { block: BlockType; index: number }) {
             key={i}
             className="relative pl-5 text-[16px] leading-relaxed text-muted before:absolute before:left-0 before:top-[0.7em] before:h-1.5 before:w-1.5 before:rounded-sm before:bg-accent"
           >
-            {li}
+            {renderInline(li)}
           </li>
         ))}
       </ul>

--- a/components/blog/inlineMarkdown.tsx
+++ b/components/blog/inlineMarkdown.tsx
@@ -1,0 +1,69 @@
+import React from "react"
+
+// 본문 텍스트의 인라인 마크다운을 React 노드로 변환한다.
+// 지원: 인라인 코드 `code`, 볼드 **bold**, 링크 [text](url).
+// (블록 레벨 — 헤딩/코드펜스/목록 — 은 상위 Block 렌더러가 처리)
+
+type Kind = "code" | "bold" | "link"
+const RULES: { kind: Kind; re: RegExp }[] = [
+  { kind: "code", re: /`([^`]+)`/ },
+  { kind: "bold", re: /\*\*([^*]+?)\*\*/ },
+  { kind: "link", re: /\[([^\]]+)\]\(([^)\s]+)\)/ },
+]
+
+function renderMatch(kind: Kind, m: RegExpMatchArray, key: number): React.ReactNode {
+  if (kind === "code")
+    return (
+      <code
+        key={key}
+        className="rounded bg-surface px-1.5 py-0.5 font-mono text-[0.88em] text-accent"
+      >
+        {m[1]}
+      </code>
+    )
+  if (kind === "bold")
+    return (
+      <strong key={key} className="font-semibold text-fg">
+        {m[1]}
+      </strong>
+    )
+  // link
+  const external = /^https?:\/\//.test(m[2])
+  return (
+    <a
+      key={key}
+      href={m[2]}
+      className="text-accent underline underline-offset-2 hover:opacity-80"
+      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+    >
+      {m[1]}
+    </a>
+  )
+}
+
+export function renderInline(text: string): React.ReactNode {
+  const nodes: React.ReactNode[] = []
+  let rest = text
+  let key = 0
+
+  while (rest.length) {
+    // 남은 문자열에서 가장 앞선 매치를 찾는다(코드 > 볼드 > 링크는 동일 위치일 때 우선순위).
+    let best: { kind: Kind; index: number; m: RegExpMatchArray } | null = null
+    for (const rule of RULES) {
+      const m = rest.match(rule.re)
+      if (m && m.index !== undefined && (best === null || m.index < best.index)) {
+        best = { kind: rule.kind, index: m.index, m }
+      }
+    }
+
+    if (!best) {
+      nodes.push(rest)
+      break
+    }
+    if (best.index > 0) nodes.push(rest.slice(0, best.index))
+    nodes.push(renderMatch(best.kind, best.m, key++))
+    rest = rest.slice(best.index + best.m[0].length)
+  }
+
+  return nodes
+}


### PR DESCRIPTION
## 배경
블로그 본문에서 인라인 마크다운이 리터럴로 노출됨 — `` `code` ``·`**bold**`·`[link]`의 백틱/별표가 그대로 보임. 블록 레벨(헤딩·코드펜스·목록)은 정상, 인라인만 미지원이었음.

Closes #42

## 변경
- `components/blog/inlineMarkdown.tsx`(신규): `renderInline(text)` — 텍스트를 스캔해 가장 앞선 매치를 골라 토큰화. `` `code` ``→`<code>`, `**bold**`→`<strong>`, `[text](url)`→`<a>`(외부 링크는 새 탭). 나머지는 평문 유지
- `app/(site)/blog/[slug]/page.tsx`: `Block` 렌더러의 **문단·목록 항목·헤딩**에 `renderInline` 적용

## 특징
- **데이터 변경 불필요** — 렌더 시점 파싱이라 이미 발행된 4편도 재작성 없이 자동 정상화
- 블록 레벨 렌더링(헤딩/코드펜스/목록)은 그대로

## 검증
- 토크나이저 로직 유닛 확인(코드/볼드/링크 분리, 혼합·평문 처리)
- `next lint`+`next build` 통과
- 병합·배포 후 `/blog/admin-token-latest-secret-pitfall` 등에서 리터럴 백틱이 인라인 코드로 렌더되는지 확인 권장