### PR TITLE
feat(seo): 메타데이터·sitemap·robots·JSON-LD·사이트 OG (트랙 A-1)

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { getPosts, getPost, getAdjacent } from "../../../../lib/postsData"
 import CodeBlock from "../../../../components/blog/codeBlock"
 import Toc from "../../../../components/blog/toc"
 import { renderInline } from "../../../../components/blog/inlineMarkdown"
+import JsonLd from "../../../../components/jsonLd"
+import { SITE_URL, AUTHOR } from "../../../../lib/site"
 
 interface TocItem {
   id: string
@@ -51,7 +53,25 @@ export async function generateMetadata({
   const { slug } = await params
   const post = await getPost(slug)
   if (!post) return {}
-  return { title: post.title }
+  const url = `${SITE_URL}/blog/${post.slug}`
+  return {
+    title: post.title,
+    description: post.summary,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "article",
+      url,
+      title: post.title,
+      description: post.summary,
+      publishedTime: post.date || undefined,
+      tags: post.tags,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.summary,
+    },
+  }
 }
 
 export default async function Post({
@@ -68,9 +88,23 @@ export default async function Post({
     .map((b, i) => (b.h ? { id: `h-${i}`, text: b.h } : null))
     .filter(Boolean) as TocItem[]
   const minutes = readingMinutes(post)
+  const url = `${SITE_URL}/blog/${post.slug}`
 
   return (
     <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          headline: post.title,
+          description: post.summary,
+          datePublished: post.date || undefined,
+          url,
+          mainEntityOfPage: url,
+          keywords: post.tags.join(", "),
+          author: { "@type": "Person", name: AUTHOR.name, url: SITE_URL },
+        }}
+      />
       <Link href="/blog" className="font-mono text-xs text-muted hover:text-accent">
         ← Blog
       </Link>

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link"
 import ProjectItem from "../../components/projects/projectItem"
 import AboutRail from "../../components/home/aboutRail"
 import { getProjects } from "../../lib/notion"
+import JsonLd from "../../components/jsonLd"
+import { SITE_URL, SITE_DESCRIPTION, AUTHOR } from "../../lib/site"
 
 export const revalidate = 3600
 
@@ -14,6 +16,18 @@ export default async function Home() {
 
   return (
     <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "Person",
+          name: AUTHOR.name,
+          alternateName: AUTHOR.alternateName,
+          jobTitle: AUTHOR.jobTitle,
+          description: SITE_DESCRIPTION,
+          url: SITE_URL,
+          sameAs: AUTHOR.sameAs,
+        }}
+      />
       {/* Masthead */}
       <section className="pb-8">
         <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,30 @@
 import "../styles/globals.css"
 import type { Metadata, Viewport } from "next"
 import Providers from "./providers"
+import { SITE_URL, SITE_NAME, SITE_TITLE, SITE_DESCRIPTION } from "../lib/site"
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: "Sejune Oh — 백엔드 개발자",
+    default: SITE_TITLE,
     template: "%s — Sejune Oh",
   },
-  description:
-    "헬스케어 SaaS의 채팅/메시징 백엔드를 설계·운영하는 C#/.NET 백엔드 개발자 오세준의 포트폴리오",
+  description: SITE_DESCRIPTION,
   icons: { icon: "/favicon.ico" },
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    locale: "ko_KR",
+    url: SITE_URL,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
 }
 
 export const viewport: Viewport = {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,39 @@
+import { ImageResponse } from "next/og"
+import { SITE_URL } from "../lib/site"
+
+// 사이트 공용 OG 이미지(링크 공유 카드). 폰트 임베드 없이 렌더되도록 라틴만 사용.
+// 글별 한국어 제목 OG 는 CJK 폰트 임베드가 필요해 별도 후속으로 처리.
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+export const alt = "Sejune Oh — Backend Engineer"
+export const runtime = "edge"
+
+export default function OpengraphImage() {
+  const domain = SITE_URL.replace(/^https?:\/\//, "")
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background: "#191919",
+          color: "#ffffff",
+        }}
+      >
+        <div style={{ fontSize: 28, letterSpacing: 8, color: "#2383e2", textTransform: "uppercase" }}>
+          Backend Engineer · Fullstack
+        </div>
+        <div style={{ fontSize: 92, fontWeight: 800, marginTop: 24, lineHeight: 1.05 }}>Sejune Oh</div>
+        <div style={{ fontSize: 34, color: "#9b9a97", marginTop: 20 }}>
+          C#/.NET · Real-time messaging backend · DDD/CQRS
+        </div>
+        <div style={{ fontSize: 24, color: "#787774", marginTop: "auto" }}>{domain}</div>
+      </div>
+    ),
+    size
+  )
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next"
+import { SITE_URL } from "../lib/site"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin", "/api/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next"
+import { SITE_URL } from "../lib/site"
+import { getPosts } from "../lib/postsData"
+
+export const revalidate = 3600
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date()
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${SITE_URL}`, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/projects`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${SITE_URL}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${SITE_URL}/resume`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${SITE_URL}/contact`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+  ]
+
+  let postRoutes: MetadataRoute.Sitemap = []
+  try {
+    const posts = await getPosts()
+    postRoutes = posts.map((p) => ({
+      url: `${SITE_URL}/blog/${p.slug}`,
+      lastModified: p.date ? new Date(p.date) : now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    }))
+  } catch {
+    // Notion 미설정/실패 시 정적 라우트만 반환
+  }
+
+  return [...staticRoutes, ...postRoutes]
+}

--- a/components/jsonLd.tsx
+++ b/components/jsonLd.tsx
@@ -1,0 +1,10 @@
+// schema.org 구조화 데이터(JSON-LD)를 <script>로 주입하는 서버 컴포넌트.
+export default function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      // 구조화 데이터는 신뢰된 서버 생성 값만 담는다(사용자 입력 이스케이프 주의).
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,18 @@
+// 사이트 전역 상수 (SEO·메타데이터·구조화 데이터 공용).
+// 커스텀 도메인 사용 시 NEXT_PUBLIC_SITE_URL 로 덮어쓴다.
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://portfolio-iota-eight-99.vercel.app"
+).replace(/\/$/, "")
+
+export const SITE_NAME = "Sejune Oh"
+export const SITE_TITLE = "Sejune Oh — 백엔드 개발자"
+export const SITE_DESCRIPTION =
+  "헬스케어 SaaS의 채팅/메시징 백엔드를 설계·운영하는 C#/.NET 백엔드 개발자 오세준의 포트폴리오"
+
+// schema.org Person / 소셜 링크
+export const AUTHOR = {
+  name: "Sejune Oh",
+  alternateName: "오세준",
+  jobTitle: "Backend Engineer",
+  sameAs: ["https://github.com/SejuneOh"],
+}


### PR DESCRIPTION
## 요약
링크 공유·검색 노출을 위한 **SEO 표면** 구축. (트랙 A의 1번 PR — OG 이미지/이미지·폰트 최적화는 후속 PR)

Refs #48

## 변경
- `lib/site.ts`: `SITE_URL`(`NEXT_PUBLIC_SITE_URL` override, 기본 iota 도메인)·이름/설명/저자 상수
- `app/layout.tsx`: `metadataBase`·기본 `openGraph`·`twitter`·canonical
- `app/(site)/blog/[slug]/page.tsx` `generateMetadata`: `description`·`openGraph`(article, publishedTime, tags)·canonical·twitter
- **JSON-LD**: 홈 `Person`, 글 `BlogPosting` (`components/jsonLd.tsx`)
- `app/sitemap.ts`(정적 + 발행 글, Notion 실패 시 정적만), `app/robots.ts`(`/admin`·`/api/` 제외 + sitemap)

## 검증
- `next lint`+`next build` 통과 — `/sitemap.xml`·`/robots.txt` 라우트 생성 확인
- 병합·배포 후: `/sitemap.xml`·`/robots.txt` 200, 글/홈 뷰소스에 OG·JSON-LD 존재, 링크 unfurl

## 참고
커스텀 도메인 쓰면 Vercel에 `NEXT_PUBLIC_SITE_URL` 설정(아니면 iota 도메인 사용).