### PR TITLE
perf(images): 프로젝트 커버 next/image 최적화 (트랙 A-3)

### DIFF
--- a/components/projects/projectItem.tsx
+++ b/components/projects/projectItem.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import Image from "next/image"
 
 export interface ProjectTag {
   id: string;
@@ -37,14 +38,14 @@ export default function ProjectItem({ data }: { data: Project }) {
   const body = (
     <>
       {/* Cover strip */}
-      <div className="aspect-[16/9] w-full overflow-hidden">
+      <div className="relative aspect-[16/9] w-full overflow-hidden">
         {data.cover ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+          <Image
             src={data.cover}
             alt=""
-            loading="lazy"
-            className="h-full w-full object-cover grayscale-[15%] opacity-95 transition group-hover:grayscale-0 group-hover:opacity-100 motion-safe:group-hover:scale-[1.03]"
+            fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            className="object-cover grayscale-[15%] opacity-95 transition group-hover:grayscale-0 group-hover:opacity-100 motion-safe:group-hover:scale-[1.03]"
           />
         ) : (
           <div

--- a/next.config.js
+++ b/next.config.js
@@ -2,10 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    // Notion 커버는 호스트가 다양(app.notion.com, S3, unsplash 등)해 호스트 화이트리스트가
-    // 계속 깨진다. 포트폴리오 규모에선 최적화보다 안정성이 중요하므로 최적화를 끄고
-    // 어떤 원격 이미지든 그대로 서빙한다.
-    unoptimized: true,
+    // Notion 커버는 S3(prod-files-secure.s3.*.amazonaws.com)·notion.so·unsplash 등에서 온다.
+    // 넓은 패턴으로 최적화를 켜되, 목록 밖 호스트 이미지는 개별 컴포넌트에서 `unoptimized`
+    // 로 폴백한다(호스트 churn 시 빌드가 아니라 해당 이미지만 영향).
+    remotePatterns: [
+      { protocol: "https", hostname: "**.amazonaws.com" },
+      { protocol: "https", hostname: "**.notion.so" },
+      { protocol: "https", hostname: "**.notion.site" },
+      { protocol: "https", hostname: "**.unsplash.com" },
+    ],
   },
 }
 


### PR DESCRIPTION
## 요약
전역 비활성이던 이미지 최적화를 재활성. 프로젝트 커버가 반응형 srcset·lazy·포맷 협상을 받아 LCP/대역폭 개선. (트랙 A의 성능 PR)

Refs #48

## 변경
- `next.config.js`: `images.unoptimized:true` 제거 → `remotePatterns`(`**.amazonaws.com`·`notion.so`·`notion.site`·`unsplash.com`). 목록 밖 호스트는 개별 이미지 `unoptimized` 폴백 가능(churn 시 빌드 아닌 해당 이미지만 영향)
- `components/projects/projectItem.tsx`: raw `<img>` → `next/image`(`fill`+`sizes`), 컨테이너 `relative`

## 검증
- `next lint`+`next build` 통과
- 병합·배포 후: 프로젝트 커버가 `/_next/image`로 서빙되는지, 이미지 정상 표시(호스트 패턴 커버) 확인

## 남은 트랙 A 후속 (이번 제외)
- 글별 **한국어 OG 이미지**(CJK 폰트 임베드 + 시각 QA 필요)
- 이력서 `next/font` 전환(단일 페이지 render-blocking 폰트)