### PR TITLE
feat(design): 딥네이비 accent·홈 h1·연락 동선·focus-visible (트랙 B-1)

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -19,6 +19,9 @@ export default async function Home() {
         <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">
           Backend Engineer · Fullstack
         </p>
+        <h1 className="mt-3 max-w-[18ch] text-2xl font-extrabold leading-tight tracking-tight text-fg sm:text-3xl">
+          실시간 채팅·메시징 백엔드를 설계·운영하는 C#/.NET 엔지니어
+        </h1>
         <p className="mt-3 font-mono text-xs tracking-widest text-muted">
           {`${projects.length}개 프로젝트 · 2019—NOW`}
         </p>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,27 +1,14 @@
-"use client"
-
-import { useState } from "react"
-import type React from "react"
 import Link from "next/link"
 
 const nav = [
   { href: "/", label: "HOME" },
   { href: "/projects", label: "PROJECTS" },
   { href: "/blog", label: "BLOG" },
+  { href: "/resume", label: "RESUME" },
   { href: "/contact", label: "CONTACT" },
 ]
 
 export default function Footer() {
-  const [email, setEmail] = useState("")
-
-  const handleSubscribe = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (!email) return
-    const subject = encodeURIComponent("포트폴리오 소식 받기")
-    const body = encodeURIComponent(`소식을 받아보고 싶습니다.\n제 이메일: ${email}`)
-    window.location.href = `mailto:etry0715@gmail.com?subject=${subject}&body=${body}`
-  }
-
   return (
     <footer className="pb-16">
       {/* divider with // mark */}
@@ -31,34 +18,21 @@ export default function Footer() {
         <div className="h-px flex-1 bg-line" />
       </div>
 
-      <div className="flex flex-col gap-10 md:flex-row md:items-start md:justify-between">
+      <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
         <nav className="flex flex-wrap gap-x-6 gap-y-2 text-sm font-bold tracking-wide text-fg">
           {nav.map((n) => (
             <Link key={n.href} href={n.href} className="hover:text-accent">
               {n.label}
             </Link>
           ))}
-          <a href="mailto:etry0715@gmail.com" className="hover:text-accent">
-            CONTACT
-          </a>
         </nav>
 
-        <form onSubmit={handleSubscribe} className="w-full md:max-w-sm">
-          <p className="mb-2 text-sm text-muted">새 글과 소식을 이메일로 받아보세요.</p>
-          <div className="flex gap-2">
-            <input
-              type="email"
-              required
-              value={email}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
-              placeholder="E-mail"
-              className="min-w-0 flex-1 rounded-md border border-line bg-surface px-3 py-2 text-sm text-fg placeholder:text-muted focus:border-accent focus:outline-none"
-            />
-            <button type="submit" className="btn-accent shrink-0">
-              Subscribe
-            </button>
-          </div>
-        </form>
+        <div className="text-sm text-muted">
+          <p>협업·채용·면접 제안은 언제든 환영합니다.</p>
+          <Link href="/contact" className="link-underline mt-1 inline-block text-accent">
+            문의 남기기 →
+          </Link>
+        </div>
       </div>
 
       <p className="mt-10 text-xs text-muted">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -9,6 +9,7 @@ const nav = [
   { href: "/projects", label: "PROJECTS" },
   { href: "/blog", label: "BLOG" },
   { href: "/resume", label: "RESUME" },
+  { href: "/contact", label: "CONTACT" },
 ]
 
 function GitHubIcon() {
@@ -52,12 +53,6 @@ export default function Sidebar() {
             {n.label}
           </Link>
         ))}
-        <a
-          href="mailto:etry0715@gmail.com"
-          className="w-fit text-lg font-bold tracking-wide text-fg transition-colors hover:text-accent"
-        >
-          CONTACT
-        </a>
       </nav>
 
       {/* Contact info */}
@@ -77,15 +72,6 @@ export default function Sidebar() {
           className="text-muted transition-colors hover:text-fg"
         >
           <GitHubIcon />
-        </a>
-        <a
-          href="https://sejuneoh.github.io/devlog/"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Blog"
-          className="text-sm text-muted transition-colors hover:text-fg"
-        >
-          Blog
         </a>
         <DarkModeToggleBtn />
       </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,8 +9,8 @@
   --text: #37352f;
   --text-muted: #787774;
   --border: #e9e9e7;
-  --accent: #2383e2;
-  --accent-hover: #0b6bcb;
+  --accent: #1d4ed8;
+  --accent-hover: #1e40af;
 }
 
 .dark {
@@ -20,8 +20,17 @@
   --text: rgba(255, 255, 255, 0.9);
   --text-muted: #9b9b98;
   --border: #2f2f2f;
-  --accent: #529cca;
-  --accent-hover: #6ab3df;
+  --accent: #3b82f6;
+  --accent-hover: #60a5fa;
+}
+
+@layer base {
+  /* 전역 키보드 포커스 표시(일관성) */
+  :where(a, button, input, textarea, select, summary):focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
 }
 
 html {


### PR DESCRIPTION
## 요약
"절제된 잉크" 방향으로 템플릿 느낌 탈피 + 홈 5초 임팩트 + 연락 동선 신뢰성. (트랙 B의 디자인/UX PR)

Refs #51

## 변경
- **accent 딥네이비 스왑**: Notion 기본 블루 `#2383e2` → `#1d4ed8`(라이트)/`#3b82f6`(다크) — `styles/globals.css`
- **전역 focus-visible** 아웃라인(a/button/input 등 키보드 포커스 일관)
- **홈 `<h1>` 가치제안**: "실시간 채팅·메시징 백엔드를 설계·운영하는 C#/.NET 엔지니어" — 5초 테스트 + 헤딩 순서 정상화 (`app/(site)/page.tsx`)
- **연락 동선 일원화**: 사이드바 CONTACT `mailto:`→`/contact` nav 항목, 외부 devlog 링크 제거 (`components/sidebar.tsx`)
- **가짜 뉴스레터 제거**: 푸터 mailto 구독폼 → `/contact` CTA, CONTACT 중복 제거, 서버 컴포넌트화 (`components/footer.tsx`)

## 검증
- `next lint`+`next build` 통과
- 병합·배포 후: accent 색 반영, 홈 h1 노출, 사이드바/푸터 CONTACT→/contact, 키보드 Tab 포커스 링 확인

## 후속(이번 제외)
모바일 헤더/햄버거, 홈/프로젝트 레이아웃 grid 통일, 이력서 사이트 통합·next/font (시각 반복 QA 필요)