### PR TITLE
feat(contact): 문의 이메일 알림(Resend) + 레이트리밋 (트랙 B-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,16 @@ AUTH_GITHUB_SECRET=
 # ── Notion (기존 프로젝트 연동 + 후속 PR) ───────────────────────────
 NOTION_TOKEN=
 NOTION_DB=
-# 후속 PR-B/PR-D 에서 사용
-# NOTION_BLOG_DB=
-# NOTION_INQUIRIES_DB=
+NOTION_BLOG_DB=
+NOTION_INQUIRIES_DB=
+
+# ── 문의 알림 (Resend, 선택) ───────────────────────────────────────
+# 미설정 시 문의는 저장만 되고 알림은 skip. resend.com API 키 + 수신 이메일.
+RESEND_API_KEY=
+CONTACT_NOTIFY_EMAIL=
+# 발신자(선택). 도메인 미검증이면 기본 onboarding@resend.dev 사용.
+# CONTACT_FROM_EMAIL=Portfolio <onboarding@resend.dev>
+
+# ── 사이트 URL (SEO/OG, 선택) ──────────────────────────────────────
+# 커스텀 도메인 사용 시. 미설정 시 기본 배포 도메인 사용.
+# NEXT_PUBLIC_SITE_URL=https://your-domain.com

--- a/app/(site)/contact/actions.ts
+++ b/app/(site)/contact/actions.ts
@@ -1,6 +1,9 @@
 "use server"
 
+import { headers } from "next/headers"
 import { createInquiry, INQUIRY_TYPES } from "../../../lib/inquiries"
+import { notifyNewInquiry } from "../../../lib/notify"
+import { rateLimit } from "../../../lib/rateLimit"
 
 export interface ContactState {
   ok: boolean
@@ -18,6 +21,13 @@ export async function submitInquiry(
     return { ok: true, message: "문의가 접수되었습니다. 감사합니다." }
   }
 
+  // 레이트리밋: IP당 10분에 3회(인스턴스별 in-memory, 기본 남용 완화).
+  const h = await headers()
+  const ip = h.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
+  if (!rateLimit(`contact:${ip}`, 3, 10 * 60 * 1000)) {
+    return { ok: false, message: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." }
+  }
+
   const name = String(formData.get("name") || "").trim()
   const email = String(formData.get("email") || "").trim()
   const type = String(formData.get("type") || "").trim()
@@ -30,6 +40,8 @@ export async function submitInquiry(
 
   try {
     await createInquiry({ name, email, type: safeType, message })
+    // 저장 성공 후 소유자에게 알림(미설정 시 skip, 실패해도 제출은 성공 처리).
+    await notifyNewInquiry({ name, email, type: safeType, message })
     return { ok: true, message: "문의가 접수되었습니다. 확인 후 회신드리겠습니다." }
   } catch (e) {
     return { ok: false, message: (e as Error).message }

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -1,0 +1,35 @@
+// 새 문의 발생 시 소유자에게 이메일 알림(Resend). 서버에서만 호출.
+// RESEND_API_KEY / CONTACT_NOTIFY_EMAIL 미설정 시 조용히 skip(저장은 그대로 진행).
+// 알림 실패가 제출 흐름을 깨지 않도록 절대 throw 하지 않는다.
+export interface InquiryNotice {
+  name: string
+  email: string
+  type: string
+  message: string
+}
+
+export async function notifyNewInquiry(n: InquiryNotice): Promise<void> {
+  const key = process.env.RESEND_API_KEY
+  const to = process.env.CONTACT_NOTIFY_EMAIL
+  if (!key || !to) return // 미설정 → 알림 없이 저장만
+
+  const from = process.env.CONTACT_FROM_EMAIL || "Portfolio <onboarding@resend.dev>"
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        from,
+        to,
+        reply_to: n.email,
+        subject: `[포트폴리오 문의] ${n.type} — ${n.name}`,
+        text: `이름: ${n.name}\n이메일: ${n.email}\n유형: ${n.type}\n\n${n.message}`,
+      }),
+    })
+    if (!res.ok) {
+      console.error("[notify] Resend 실패:", res.status, (await res.text().catch(() => "")).slice(0, 200))
+    }
+  } catch (e) {
+    console.error("[notify] 오류:", (e as Error).message)
+  }
+}

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,16 @@
+// 간단 in-memory 슬라이딩 윈도우 레이트리밋. 서버리스 인스턴스별이라 완벽하진 않지만
+// 공개 폼의 기본 스팸/남용 완화용으로 충분. 허니팟과 함께 다층 방어.
+const hits = new Map<string, number[]>()
+
+// 허용이면 true, 한도 초과면 false.
+export function rateLimit(key: string, max: number, windowMs: number): boolean {
+  const now = Date.now()
+  const recent = (hits.get(key) || []).filter((t) => now - t < windowMs)
+  if (recent.length >= max) {
+    hits.set(key, recent)
+    return false
+  }
+  recent.push(now)
+  hits.set(key, recent)
+  return true
+}


### PR DESCRIPTION
## 요약
문의(면접·이메일 요청) 제출 시 소유자에게 **이메일 알림**(Resend) + 공개 폼 **레이트리밋**. 방치 위험 해소.

Refs #51

## 변경
- `lib/notify.ts`: Resend REST로 알림 메일(제목 `[포트폴리오 문의] {유형} — {이름}`, reply-to=제출자). **키 미설정 시 skip, 실패해도 제출은 성공**(throw 안 함)
- `lib/rateLimit.ts`: in-memory 슬라이딩 윈도우(IP당 10분 3회) — 허니팟과 다층 방어
- `app/(site)/contact/actions.ts`: 레이트리밋 게이트 + 저장 성공 후 `notifyNewInquiry`
- `.env.example`: `RESEND_API_KEY`·`CONTACT_NOTIFY_EMAIL`·`CONTACT_FROM_EMAIL`·`NEXT_PUBLIC_SITE_URL`

## 준비물 (배포자)
- Resend API 키 + 수신 이메일을 Vercel env(`RESEND_API_KEY`, `CONTACT_NOTIFY_EMAIL`)에 등록. 없으면 저장만 되고 알림은 skip(코드는 안전).

## 검증
- `next lint`+`next build` 통과
- 키 설정 후 테스트 제출 → 알림 메일 수신 + `/admin` 목록 반영, 짧은 시간 반복 제출 시 레이트리밋 메시지