### PR TITLE
fix(projects): 커버 이미지 400 — next/image unoptimized 폴백

### DIFF
--- a/components/projects/projectItem.tsx
+++ b/components/projects/projectItem.tsx
@@ -45,6 +45,9 @@ export default function ProjectItem({ data }: { data: Project }) {
             alt=""
             fill
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            // Notion 커버 호스트(app.notion.com 등)가 remotePatterns 밖이면 최적화기가 400.
+            // 커버는 임의 호스트라 unoptimized 로 원본 서빙(어떤 호스트든 표시 보장). lazy/레이아웃은 유지.
+            unoptimized
             className="object-cover grayscale-[15%] opacity-95 transition group-hover:grayscale-0 group-hover:opacity-100 motion-safe:group-hover:scale-[1.03]"
           />
         ) : (


### PR DESCRIPTION
## 증상
프로덕션 홈/프로젝트에서 커버 이미지 미표시, `/_next/image` 400.

## 원인
PR #50에서 커버를 `next/image`로 전환 + `remotePatterns` 허용목록 방식. 실제 Notion 커버 호스트가 **`app.notion.com`**(목록 밖) → 최적화기 400. Notion 커버는 사용자가 임의 호스트로 설정 가능해 목록 방식은 churn에 취약.

Closes #61

## 해결
커버 `<Image>`에 **`unoptimized`** — 최적화기를 우회해 원본 URL을 서빙(호스트 무관 표시 보장). `next/image`의 lazy·`fill` 레이아웃은 유지. (커버는 3개·프리셋이라 최적화 이득 작음 → 신뢰성 우선)

## 검증
- `next lint`+`next build` 통과
- 병합·배포 후 홈/프로젝트 커버 정상 표시(400 사라짐) 확인