### PR TITLE
feat(projects): 프로젝트 상세 페이지 /projects/[id] (C-2)

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -1,43 +1,16 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
-import type { Block as BlockType } from "../../../../lib/posts"
 import { readingMinutes } from "../../../../lib/posts"
 import { getPosts, getPost, getAdjacent } from "../../../../lib/postsData"
-import CodeBlock from "../../../../components/blog/codeBlock"
 import Toc from "../../../../components/blog/toc"
-import { renderInline } from "../../../../components/blog/inlineMarkdown"
+import PostBody from "../../../../components/postBody"
 import JsonLd from "../../../../components/jsonLd"
 import { SITE_URL, AUTHOR } from "../../../../lib/site"
 
 interface TocItem {
   id: string
   text: string
-}
-
-function Block({ block, index }: { block: BlockType; index: number }) {
-  if (block.h)
-    return (
-      <h2 id={`h-${index}`} className="mt-10 mb-3 scroll-mt-24 text-2xl font-bold text-fg">
-        {renderInline(block.h)}
-      </h2>
-    )
-  if (block.p) return <p className="mt-4 text-[16px] leading-[1.8] text-muted">{renderInline(block.p)}</p>
-  if (block.code) return <CodeBlock code={block.code} lang={block.lang} />
-  if (block.ul)
-    return (
-      <ul className="mt-4 space-y-2">
-        {block.ul.map((li, i) => (
-          <li
-            key={i}
-            className="relative pl-5 text-[16px] leading-relaxed text-muted before:absolute before:left-0 before:top-[0.7em] before:h-1.5 before:w-1.5 before:rounded-sm before:bg-accent"
-          >
-            {renderInline(li)}
-          </li>
-        ))}
-      </ul>
-    )
-  return null
 }
 
 export async function generateStaticParams() {
@@ -128,9 +101,7 @@ export default async function Post({
           </div>
 
           <div className="mt-8 border-t border-line pt-2">
-            {post.body.map((block, i) => (
-              <Block key={i} block={block} index={i} />
-            ))}
+            <PostBody blocks={post.body} />
           </div>
 
           {/* prev / next */}

--- a/app/(site)/projects/[id]/page.tsx
+++ b/app/(site)/projects/[id]/page.tsx
@@ -1,0 +1,110 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+import { getProjects, getProject } from "../../../../lib/notion"
+import { fetchBody } from "../../../../lib/postsData"
+import type { Block } from "../../../../lib/posts"
+import PostBody from "../../../../components/postBody"
+import { SITE_URL } from "../../../../lib/site"
+
+export const revalidate = 3600
+
+export async function generateStaticParams() {
+  const projects = await getProjects()
+  return projects.map((p) => ({ id: p.id }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const project = await getProject(id)
+  if (!project) return {}
+  const url = `${SITE_URL}/projects/${id}`
+  return {
+    title: project.projectName,
+    description: project.description || undefined,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "article",
+      url,
+      title: project.projectName,
+      description: project.description || undefined,
+    },
+  }
+}
+
+export default async function ProjectDetail({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const project = await getProject(id)
+  if (!project) notFound()
+
+  // 프로젝트 페이지 본문(케이스스터디). fallback/미설정 등으로 없으면 빈 배열.
+  let body: Block[] = []
+  try {
+    body = await fetchBody(id)
+  } catch {
+    body = []
+  }
+
+  const period = [project.startDate, project.endDate].filter(Boolean).join(" — ")
+
+  return (
+    <div className="max-w-[720px]">
+      <Link href="/projects" className="font-mono text-xs text-muted hover:text-accent">
+        ← Projects
+      </Link>
+
+      <div className="mt-6 flex flex-wrap items-center gap-2 font-mono text-xs text-accent">
+        {period && <span>{period}</span>}
+        {project.status && (
+          <>
+            {period && <span className="text-muted">·</span>}
+            <span>완료</span>
+          </>
+        )}
+      </div>
+
+      <h1 className="mt-3 text-3xl font-bold leading-tight tracking-tight text-fg sm:text-4xl">
+        {project.projectName}
+      </h1>
+
+      {project.description && (
+        <p className="mt-3 text-[15px] leading-relaxed text-muted">{project.description}</p>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {project.tags.map((t) => (
+          <span key={t.id} className="chip">
+            {t.name}
+          </span>
+        ))}
+      </div>
+
+      {project.url && (
+        <div className="mt-5">
+          <a
+            href={project.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="link-underline text-sm text-accent"
+          >
+            GitHub / 링크 →
+          </a>
+        </div>
+      )}
+
+      {body.length > 0 && (
+        <div className="mt-8 border-t border-line pt-2">
+          <PostBody blocks={body} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/postBody.tsx
+++ b/components/postBody.tsx
@@ -1,0 +1,41 @@
+import type { Block } from "../lib/posts"
+import CodeBlock from "./blog/codeBlock"
+import { renderInline } from "./blog/inlineMarkdown"
+
+// 본문 블록 렌더러 — 블로그 글·프로젝트 상세가 공유.
+// 헤딩 id(h-{index})는 TOC 스크롤스파이 호환용.
+function BlockView({ block, index }: { block: Block; index: number }) {
+  if (block.h)
+    return (
+      <h2 id={`h-${index}`} className="mt-10 mb-3 scroll-mt-24 text-2xl font-bold text-fg">
+        {renderInline(block.h)}
+      </h2>
+    )
+  if (block.p)
+    return <p className="mt-4 text-[16px] leading-[1.8] text-muted">{renderInline(block.p)}</p>
+  if (block.code) return <CodeBlock code={block.code} lang={block.lang} />
+  if (block.ul)
+    return (
+      <ul className="mt-4 space-y-2">
+        {block.ul.map((li, i) => (
+          <li
+            key={i}
+            className="relative pl-5 text-[16px] leading-relaxed text-muted before:absolute before:left-0 before:top-[0.7em] before:h-1.5 before:w-1.5 before:rounded-sm before:bg-accent"
+          >
+            {renderInline(li)}
+          </li>
+        ))}
+      </ul>
+    )
+  return null
+}
+
+export default function PostBody({ blocks }: { blocks: Block[] }) {
+  return (
+    <>
+      {blocks.map((b, i) => (
+        <BlockView key={i} block={b} index={i} />
+      ))}
+    </>
+  )
+}

--- a/components/projects/projectItem.tsx
+++ b/components/projects/projectItem.tsx
@@ -100,29 +100,18 @@ export default function ProjectItem({ data }: { data: Project }) {
 
         <div className="mt-auto flex items-center justify-between border-t border-line pt-4">
           <span className="font-mono text-xs text-muted">{hasPeriod ? period : ""}</span>
-          {data.url && (
-            <span className="text-sm text-accent group-hover:text-accent-hover">
-              GitHub →
-            </span>
-          )}
+          <span className="text-sm text-accent group-hover:text-accent-hover">
+            자세히 →
+          </span>
         </div>
       </div>
     </>
   );
 
-  // 카드 전체를 하나의 링크로: url 있으면 외부 GitHub, 없으면 /projects 로.
+  // 카드 전체를 프로젝트 상세 페이지 링크로(케이스스터디). GitHub/live 링크는 상세에서 노출.
   // 앵커 중첩을 피하기 위해 내부에는 별도의 <a>/<Link> 를 두지 않는다.
-  return data.url ? (
-    <a
-      href={data.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cardClass}
-    >
-      {body}
-    </a>
-  ) : (
-    <Link href="/projects" className={cardClass}>
+  return (
+    <Link href={`/projects/${data.id}`} className={cardClass}>
       {body}
     </Link>
   );

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -27,6 +27,30 @@ interface NotionQueryResponse {
   results?: NotionPage[]
 }
 
+function mapProject(data: NotionPage): Project {
+  const p = data.properties || {}
+  return {
+    id: data.id,
+    projectName: p.projectName?.title?.[0]?.plain_text ?? "",
+    description: p.description?.rich_text?.[0]?.plain_text ?? "",
+    cover: data.cover?.external?.url || data.cover?.file?.url || "",
+    tags: p.tag?.multi_select ?? [],
+    url: p.github?.url || "",
+    startDate: p.workPeriod?.date?.start || "",
+    endDate: p.workPeriod?.date?.end || "",
+    status: p.status?.status?.name === "Done",
+  }
+}
+
+function notionHeaders() {
+  return {
+    accept: "application/json",
+    "Notion-Version": "2022-06-28",
+    "content-type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  }
+}
+
 export async function getProjects(): Promise<Project[]> {
   // 토큰/DB가 없거나 요청이 실패해도 빌드가 깨지지 않도록 방어적으로 처리
   if (!TOKEN || !DATABASE_ID) {
@@ -56,20 +80,7 @@ export async function getProjects(): Promise<Project[]> {
     if (!res.ok) throw new Error(`Notion API ${res.status}`)
     const projects = (await res.json()) as NotionQueryResponse
 
-    const ProjectArr: Project[] = (projects.results || []).map((data) => {
-      const p = data.properties || {}
-      return {
-        id: data.id,
-        projectName: p.projectName?.title?.[0]?.plain_text ?? "",
-        description: p.description?.rich_text?.[0]?.plain_text ?? "",
-        cover: data.cover?.external?.url || data.cover?.file?.url || "",
-        tags: p.tag?.multi_select ?? [],
-        url: p.github?.url || "",
-        startDate: p.workPeriod?.date?.start || "",
-        endDate: p.workPeriod?.date?.end || "",
-        status: p.status?.status?.name === "Done",
-      }
-    })
+    const ProjectArr: Project[] = (projects.results || []).map(mapProject)
 
     // 결과가 비어 있으면 큐레이션된 대체 목록으로 폴백
     if (ProjectArr.length === 0) {
@@ -81,4 +92,24 @@ export async function getProjects(): Promise<Project[]> {
     console.error("[projects] Notion fetch failed:", (e as Error).message)
     return fallbackProjects
   }
+}
+
+// 단건 프로젝트(상세 페이지용). Notion 미설정/실패/미발견 시 fallback 에서 조회.
+export async function getProject(id: string): Promise<Project | null> {
+  if (TOKEN && DATABASE_ID) {
+    try {
+      const res = await fetch(`https://api.notion.com/v1/pages/${id}`, {
+        headers: notionHeaders(),
+        next: { revalidate: 3600 },
+      })
+      if (res.ok) {
+        const page = (await res.json()) as NotionPage
+        const proj = mapProject(page)
+        if (proj.projectName) return proj
+      }
+    } catch (e) {
+      console.error("[project] Notion fetch failed:", (e as Error).message)
+    }
+  }
+  return fallbackProjects.find((p) => p.id === id) ?? null
 }

--- a/lib/postsData.ts
+++ b/lib/postsData.ts
@@ -83,7 +83,8 @@ function readCheckbox(page: NotionPage, name: string): boolean {
 // 페이지 하위 블록을 조회해 렌더용 Block[] 로 변환.
 // 연속된 목록 아이템은 하나의 { ul } 로 묶는다.
 // fresh=true 면 캐시 우회(관리자 수정 프리필 등 최신값이 필요할 때).
-async function fetchBody(pageId: string, fresh = false): Promise<Block[]> {
+// 임의 Notion 페이지의 하위 블록을 렌더용 Block[] 로. 블로그·프로젝트 상세가 공용.
+export async function fetchBody(pageId: string, fresh = false): Promise<Block[]> {
   // 100개 초과 블록도 모두 읽도록 start_cursor 페이지네이션.
   const results: NotionBlock[] = []
   let cursor: string | undefined


### PR DESCRIPTION
## 요약
프로젝트를 카드→외부 GitHub로만 넘기던 구조에서 **케이스스터디 상세 페이지**를 신설. 백엔드 서사(문제→아키텍처→지표)를 사이트 안에서 보여줌. (콘텐츠 신뢰도 트랙 C-2)

Closes #58

## 변경
- **`components/postBody.tsx`(신규)**: 블록 렌더러 공용화 — 블로그·프로젝트 상세가 **같은 렌더러**(Shiki 하이라이트 CodeBlock + 인라인 마크다운) 공유. 블로그 `[slug]`도 이걸 재사용하도록 리팩터(중복 제거)
- **`lib/notion.ts`**: `mapProject` 추출 + `getProject(id)`(단건 조회, Notion 미설정/실패 시 fallback)
- **`lib/postsData.ts`**: `fetchBody` export(임의 페이지 본문 공용)
- **`app/(site)/projects/[id]/page.tsx`(신규)**: Notion 프로젝트 페이지 본문 렌더 + 기간·태그·GitHub/링크, `generateStaticParams`·`generateMetadata`(canonical/OG)
- **`projectItem.tsx`**: 카드 링크를 외부 GitHub → **상세 페이지**로, 하단 표시 "자세히 →". (GitHub/live 링크는 상세에서)

## 검증
- `next lint`+`next build` 통과 — `/projects/[id]` SSG로 프로젝트별 프리빌드 확인, 블로그 렌더 회귀 없음
- 병합·배포 후: 카드 클릭→상세, Notion 본문·코드 하이라이트 렌더, GitHub 링크 확인
- 본문 없는(fallback/설정없음) 프로젝트는 메타만 렌더(안전)