### PR TITLE
chore: .gitignore 에 .claude/ 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Claude Code (로컬 워크트리·세션 메타)
+.claude/


### PR DESCRIPTION
로컬 워크트리·세션 메타가 담기는 `.claude/` 를 .gitignore 에 추가(실수 커밋 방지). 현재 추적 파일 없어 영향 없음.

Closes #64