### PR TITLE
feat: 프로젝트 상세 페이지 케이스스터디 구조 개편

### DIFF
--- a/app/(site)/projects/[id]/page.tsx
+++ b/app/(site)/projects/[id]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import Image from "next/image"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 import { getProjects, getProject } from "../../../../lib/notion"
@@ -23,16 +24,12 @@ export async function generateMetadata({
   const project = await getProject(id)
   if (!project) return {}
   const url = `${SITE_URL}/projects/${id}`
+  const desc = project.impact || project.description || undefined
   return {
     title: project.projectName,
-    description: project.description || undefined,
+    description: desc,
     alternates: { canonical: url },
-    openGraph: {
-      type: "article",
-      url,
-      title: project.projectName,
-      description: project.description || undefined,
-    },
+    openGraph: { type: "article", url, title: project.projectName, description: desc },
   }
 }
 
@@ -45,7 +42,7 @@ export default async function ProjectDetail({
   const project = await getProject(id)
   if (!project) notFound()
 
-  // 프로젝트 페이지 본문(케이스스터디). fallback/미설정 등으로 없으면 빈 배열.
+  // 케이스스터디 본문(문제/접근/아키텍처/결과). 미설정 시 빈 배열 → 히어로+메타만 노출.
   let body: Block[] = []
   try {
     body = await fetchBody(id)
@@ -54,57 +51,133 @@ export default async function ProjectDetail({
   }
 
   const period = [project.startDate, project.endDate].filter(Boolean).join(" — ")
+  const statusLabel = project.status ? "완료" : "진행 중"
+  const hook = project.impact?.trim()
+  const desc = project.description?.trim()
+
+  const metaRows = [
+    project.role?.trim() && { label: "역할", value: project.role.trim() },
+    project.teamSize?.trim() && { label: "팀", value: project.teamSize.trim() },
+    period && { label: "기간", value: period },
+  ].filter(Boolean) as { label: string; value: string }[]
+
+  const hasMeta = metaRows.length > 0 || project.tags.length > 0
 
   return (
-    <div className="max-w-[720px]">
+    <article className="max-w-[760px]">
       <Link href="/projects" className="font-mono text-xs text-muted hover:text-accent">
         ← Projects
       </Link>
 
-      <div className="mt-6 flex flex-wrap items-center gap-2 font-mono text-xs text-accent">
-        {period && <span>{period}</span>}
-        {project.status && (
-          <>
-            {period && <span className="text-muted">·</span>}
-            <span>완료</span>
-          </>
-        )}
-      </div>
-
-      <h1 className="mt-3 text-3xl font-bold leading-tight tracking-tight text-fg sm:text-4xl">
-        {project.projectName}
-      </h1>
-
-      {project.description && (
-        <p className="mt-3 text-[15px] leading-relaxed text-muted">{project.description}</p>
-      )}
-
-      <div className="mt-4 flex flex-wrap gap-1.5">
-        {project.tags.map((t) => (
-          <span key={t.id} className="chip">
-            {t.name}
-          </span>
-        ))}
-      </div>
-
-      {project.url && (
-        <div className="mt-5">
-          <a
-            href={project.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="link-underline text-sm text-accent"
-          >
-            GitHub / 링크 →
-          </a>
+      {/* Hero cover (선택) */}
+      {project.cover && (
+        <div className="relative mt-6 aspect-[2/1] w-full overflow-hidden rounded-xl border border-line">
+          <Image
+            src={project.cover}
+            alt=""
+            fill
+            sizes="760px"
+            unoptimized
+            className="object-cover"
+            priority
+          />
         </div>
       )}
 
+      {/* Hero */}
+      <header className="mt-6">
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 font-mono text-[11px] uppercase tracking-widest ${
+            project.status ? "border-line text-muted" : "border-accent/40 text-accent"
+          }`}
+        >
+          <span aria-hidden>{project.status ? "○" : "●"}</span>
+          {statusLabel}
+        </span>
+
+        <h1 className="mt-4 text-3xl font-bold leading-tight tracking-tight text-fg sm:text-4xl">
+          {project.projectName}
+        </h1>
+
+        {/* 임팩트 한 줄(3초 훅). 없으면 설명이 리드 역할. */}
+        {hook ? (
+          <>
+            <p className="mt-4 text-lg font-medium leading-relaxed text-fg">{hook}</p>
+            {desc && <p className="mt-2 text-[15px] leading-relaxed text-muted">{desc}</p>}
+          </>
+        ) : (
+          desc && <p className="mt-4 text-lg leading-relaxed text-muted">{desc}</p>
+        )}
+
+        {/* CTA */}
+        {(project.url || project.liveUrl) && (
+          <div className="mt-6 flex flex-wrap gap-3">
+            {project.liveUrl && (
+              <a
+                href={project.liveUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                라이브 데모 ↗
+              </a>
+            )}
+            {project.url && (
+              <a
+                href={project.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-line px-4 py-2 text-sm font-medium text-fg transition-colors hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+              >
+                Repository ↗
+              </a>
+            )}
+          </div>
+        )}
+      </header>
+
+      {/* At-a-glance 메타 */}
+      {hasMeta && (
+        <dl className="mt-8 grid grid-cols-1 gap-x-8 gap-y-4 rounded-xl border border-line bg-surface p-5 sm:grid-cols-2">
+          {metaRows.map((r) => (
+            <div key={r.label} className="flex flex-col gap-0.5">
+              <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">
+                {r.label}
+              </dt>
+              <dd className="text-sm text-fg">{r.value}</dd>
+            </div>
+          ))}
+          {project.tags.length > 0 && (
+            <div className="flex flex-col gap-1.5 sm:col-span-2">
+              <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">스택</dt>
+              <dd className="flex flex-wrap gap-1.5">
+                {project.tags.map((t) => (
+                  <span key={t.id} className="chip">
+                    {t.name}
+                  </span>
+                ))}
+              </dd>
+            </div>
+          )}
+        </dl>
+      )}
+
+      {/* 케이스스터디 본문 */}
       {body.length > 0 && (
-        <div className="mt-8 border-t border-line pt-2">
+        <div className="mt-10 border-t border-line pt-2">
           <PostBody blocks={body} />
         </div>
       )}
-    </div>
+
+      {/* Footer nav */}
+      <nav className="mt-14 flex items-center justify-between border-t border-line pt-6 text-sm">
+        <Link href="/projects" className="text-muted transition-colors hover:text-accent">
+          ← 전체 프로젝트
+        </Link>
+        <Link href="/contact" className="text-accent transition-colors hover:text-accent-hover">
+          함께 일하기 →
+        </Link>
+      </nav>
+    </article>
   )
 }

--- a/components/projects/projectItem.tsx
+++ b/components/projects/projectItem.tsx
@@ -16,6 +16,11 @@ export interface Project {
   startDate: string;
   endDate: string;
   status: boolean;
+  // 케이스스터디용 구조화 필드(선택). Notion 미설정 시 빈 값 → 상세에서 우아하게 폴백.
+  impact?: string;
+  role?: string;
+  teamSize?: string;
+  liveUrl?: string;
 }
 
 const cardClass =

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -17,6 +17,10 @@ interface NotionProperties {
   github?: { url?: string }
   workPeriod?: { date?: { start?: string; end?: string } }
   status?: { status?: { name?: string } }
+  impact?: { rich_text?: NotionText[] }
+  role?: { rich_text?: NotionText[] }
+  teamSize?: { rich_text?: NotionText[] }
+  liveUrl?: { url?: string }
 }
 interface NotionPage {
   id: string
@@ -39,6 +43,10 @@ function mapProject(data: NotionPage): Project {
     startDate: p.workPeriod?.date?.start || "",
     endDate: p.workPeriod?.date?.end || "",
     status: p.status?.status?.name === "Done",
+    impact: p.impact?.rich_text?.[0]?.plain_text ?? "",
+    role: p.role?.rich_text?.[0]?.plain_text ?? "",
+    teamSize: p.teamSize?.rich_text?.[0]?.plain_text ?? "",
+    liveUrl: p.liveUrl?.url || "",
   }
 }
 


### PR DESCRIPTION
## 요약
프로젝트 상세 페이지(`/projects/[id]`)를 단순 메타 나열에서 **케이스스터디 구조**로 개편했다. 방문자가 상단 3초 안에 임팩트를 파악하고, 문제 → 접근 → 아키텍처 → 결과 흐름으로 실력을 읽어낼 수 있도록 한다.

## 변경 내용
- **상세 페이지 레이아웃 재구성** (`app/(site)/projects/[id]/page.tsx`)
  - 히어로: 상태 배지 + 제목 + **임팩트 한 줄**(측정 수치용) + repo/라이브 데모 버튼 + 선택적 커버 배너
  - 메타 요약 카드: 역할 · 팀 규모 · 기간 · 스택
  - 케이스스터디 본문(Notion 페이지 본문) + 하단 내비(전체 프로젝트 / 연락)
- **구조화 데이터 필드 반영** (`lib/notion.ts`, `components/projects/projectItem.tsx`)
  - `Project` 타입에 `impact`/`role`/`teamSize`/`liveUrl` 추가(모두 선택)
  - `mapProject`에서 Notion 속성 매핑, `generateMetadata` description은 `impact` 우선
  - Notion projects DB에도 동일 필드 추가 완료(별도 UI 작업)
- **빈 값 폴백**: 신규 필드나 본문이 비어 있어도 레이아웃이 깨지지 않고 자연스럽게 축약

## 검증
- `next lint` 통과(기존 resumeDoc 폰트 경고만 잔존, 본 변경 무관)
- `next build` 통과 — `/projects/[id]` SSG 생성 확인

## 남은 작업(리뷰어 참고)
- 각 프로젝트의 `impact`/`role`/본문(문제·접근·아키텍처·결과)은 Notion에서 채워야 실제 케이스스터디가 완성됨(코드는 준비 완료)

Closes #67
관련: #51