### PR TITLE
feat: 프로젝트를 대분류(경험 그룹) 구조로 재구성

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import ProjectItem from "../../components/projects/projectItem"
 import AboutRail from "../../components/home/aboutRail"
-import { getProjects } from "../../lib/notion"
+import { getProjectGroups } from "../../lib/notion"
 import JsonLd from "../../components/jsonLd"
 import { SITE_URL, SITE_DESCRIPTION, AUTHOR } from "../../lib/site"
 
@@ -10,9 +10,9 @@ export const revalidate = 3600
 const HOME_CAP = 7
 
 export default async function Home() {
-  const projects = await getProjects()
-  const homeProjects = projects.slice(0, HOME_CAP)
-  const hasMore = projects.length > homeProjects.length
+  const groups = await getProjectGroups()
+  const homeGroups = groups.slice(0, HOME_CAP)
+  const hasMore = groups.length > homeGroups.length
 
   return (
     <>
@@ -37,7 +37,7 @@ export default async function Home() {
           실시간 채팅·메시징 백엔드를 설계·운영하는 C#/.NET 엔지니어
         </h1>
         <p className="mt-3 font-mono text-xs tracking-widest text-muted">
-          {`${projects.length}개 프로젝트 · 2019—NOW`}
+          {`${groups.length}개 프로젝트 · 2019—NOW`}
         </p>
       </section>
 
@@ -48,13 +48,13 @@ export default async function Home() {
         {/* LEFT: project index */}
         <div className="lg:order-first">
           <div className="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2">
-            {homeProjects.map((p, i) =>
+            {homeGroups.map((g, i) =>
               i === 0 ? (
-                <div key={p.id} className="sm:col-span-2">
-                  <ProjectItem data={p} />
+                <div key={g.slug} className="sm:col-span-2">
+                  <ProjectItem data={g} />
                 </div>
               ) : (
-                <ProjectItem key={p.id} data={p} />
+                <ProjectItem key={g.slug} data={g} />
               )
             )}
           </div>

--- a/app/(site)/projects/[id]/page.tsx
+++ b/app/(site)/projects/[id]/page.tsx
@@ -2,17 +2,16 @@ import Link from "next/link"
 import Image from "next/image"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
-import { getProjects, getProject } from "../../../../lib/notion"
-import { fetchBody } from "../../../../lib/postsData"
-import type { Block } from "../../../../lib/posts"
+import { getProjectGroups, getProjectGroup } from "../../../../lib/notion"
+import type { Experience } from "../../../../components/projects/projectItem"
 import PostBody from "../../../../components/postBody"
 import { SITE_URL } from "../../../../lib/site"
 
 export const revalidate = 3600
 
 export async function generateStaticParams() {
-  const projects = await getProjects()
-  return projects.map((p) => ({ id: p.id }))
+  const groups = await getProjectGroups()
+  return groups.map((g) => ({ id: g.slug }))
 }
 
 export async function generateMetadata({
@@ -21,16 +20,85 @@ export async function generateMetadata({
   params: Promise<{ id: string }>
 }): Promise<Metadata> {
   const { id } = await params
-  const project = await getProject(id)
-  if (!project) return {}
+  const group = await getProjectGroup(id)
+  if (!group) return {}
   const url = `${SITE_URL}/projects/${id}`
-  const desc = project.impact || project.description || undefined
+  const desc = group.summary || group.experiences[0]?.impact || undefined
   return {
-    title: project.projectName,
+    title: group.name,
     description: desc,
     alternates: { canonical: url },
-    openGraph: { type: "article", url, title: project.projectName, description: desc },
+    openGraph: { type: "article", url, title: group.name, description: desc },
   }
+}
+
+// "2024-09-01" / "2024.09" → "2024.09"
+function fmt(d?: string) {
+  if (!d) return ""
+  const [y, m] = d.replace(/\./g, "-").split("-")
+  return m ? `${y}.${m}` : y
+}
+
+function periodOf(e: Experience) {
+  return [fmt(e.startDate), e.status ? fmt(e.endDate) : "현재"]
+    .filter(Boolean)
+    .join(" — ")
+}
+
+const CTA_LIVE =
+  "inline-flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+const CTA_REPO =
+  "inline-flex items-center gap-1.5 rounded-lg border border-line px-4 py-2 text-sm font-medium text-fg transition-colors hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+
+function Cta({ e }: { e: Experience }) {
+  if (!e.url && !e.liveUrl) return null
+  return (
+    <div className="mt-4 flex flex-wrap gap-3">
+      {e.liveUrl && (
+        <a href={e.liveUrl} target="_blank" rel="noopener noreferrer" className={CTA_LIVE}>
+          라이브 데모 ↗
+        </a>
+      )}
+      {e.url && (
+        <a href={e.url} target="_blank" rel="noopener noreferrer" className={CTA_REPO}>
+          Repository ↗
+        </a>
+      )}
+    </div>
+  )
+}
+
+// 경험 단위 메타(역할·팀·기간·스택) 카드.
+function ExperienceMeta({ e }: { e: Experience }) {
+  const period = periodOf(e)
+  const rows = [
+    e.role?.trim() && { label: "역할", value: e.role.trim() },
+    e.teamSize?.trim() && { label: "팀", value: e.teamSize.trim() },
+    period && { label: "기간", value: period },
+  ].filter(Boolean) as { label: string; value: string }[]
+  if (rows.length === 0 && e.tags.length === 0) return null
+  return (
+    <dl className="mt-6 grid grid-cols-1 gap-x-8 gap-y-4 rounded-xl border border-line bg-surface p-5 sm:grid-cols-2">
+      {rows.map((r) => (
+        <div key={r.label} className="flex flex-col gap-0.5">
+          <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">{r.label}</dt>
+          <dd className="text-sm text-fg">{r.value}</dd>
+        </div>
+      ))}
+      {e.tags.length > 0 && (
+        <div className="flex flex-col gap-1.5 sm:col-span-2">
+          <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">스택</dt>
+          <dd className="flex flex-wrap gap-1.5">
+            {e.tags.map((t) => (
+              <span key={t.id} className="chip">
+                {t.name}
+              </span>
+            ))}
+          </dd>
+        </div>
+      )}
+    </dl>
+  )
 }
 
 export default async function ProjectDetail({
@@ -39,29 +107,18 @@ export default async function ProjectDetail({
   params: Promise<{ id: string }>
 }) {
   const { id } = await params
-  const project = await getProject(id)
-  if (!project) notFound()
+  const group = await getProjectGroup(id)
+  if (!group) notFound()
 
-  // 케이스스터디 본문(문제/접근/아키텍처/결과). 미설정 시 빈 배열 → 히어로+메타만 노출.
-  let body: Block[] = []
-  try {
-    body = await fetchBody(id)
-  } catch {
-    body = []
-  }
+  const multi = group.count > 1
+  const lead = group.experiences[0]
+  const groupPeriod = [fmt(group.startDate), group.inProgress ? "현재" : fmt(group.endDate)]
+    .filter(Boolean)
+    .join(" — ")
 
-  const period = [project.startDate, project.endDate].filter(Boolean).join(" — ")
-  const statusLabel = project.status ? "완료" : "진행 중"
-  const hook = project.impact?.trim()
-  const desc = project.description?.trim()
-
-  const metaRows = [
-    project.role?.trim() && { label: "역할", value: project.role.trim() },
-    project.teamSize?.trim() && { label: "팀", value: project.teamSize.trim() },
-    period && { label: "기간", value: period },
-  ].filter(Boolean) as { label: string; value: string }[]
-
-  const hasMeta = metaRows.length > 0 || project.tags.length > 0
+  // 단일 경험: 히어로 리드 = 경험 임팩트(없으면 개요), 서브 = 설명.
+  const heroLead = multi ? group.summary : lead?.impact?.trim() || group.summary
+  const heroSub = multi ? "" : lead?.description?.trim()
 
   return (
     <article className="max-w-[760px]">
@@ -70,10 +127,10 @@ export default async function ProjectDetail({
       </Link>
 
       {/* Hero cover (선택) */}
-      {project.cover && (
+      {group.cover && (
         <div className="relative mt-6 aspect-[2/1] w-full overflow-hidden rounded-xl border border-line">
           <Image
-            src={project.cover}
+            src={group.cover}
             alt=""
             fill
             sizes="760px"
@@ -84,89 +141,95 @@ export default async function ProjectDetail({
         </div>
       )}
 
-      {/* Hero */}
+      {/* Group hero */}
       <header className="mt-6">
         <span
           className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 font-mono text-[11px] uppercase tracking-widest ${
-            project.status ? "border-line text-muted" : "border-accent/40 text-accent"
+            group.inProgress ? "border-accent/40 text-accent" : "border-line text-muted"
           }`}
         >
-          <span aria-hidden>{project.status ? "○" : "●"}</span>
-          {statusLabel}
+          <span aria-hidden>{group.inProgress ? "●" : "○"}</span>
+          {group.inProgress ? "진행 중" : "완료"}
         </span>
 
         <h1 className="mt-4 text-3xl font-bold leading-tight tracking-tight text-fg sm:text-4xl">
-          {project.projectName}
+          {group.name}
         </h1>
 
-        {/* 임팩트 한 줄(3초 훅). 없으면 설명이 리드 역할. */}
-        {hook ? (
-          <>
-            <p className="mt-4 text-lg font-medium leading-relaxed text-fg">{hook}</p>
-            {desc && <p className="mt-2 text-[15px] leading-relaxed text-muted">{desc}</p>}
-          </>
-        ) : (
-          desc && <p className="mt-4 text-lg leading-relaxed text-muted">{desc}</p>
+        {heroLead && (
+          <p className="mt-4 text-lg font-medium leading-relaxed text-fg">{heroLead}</p>
+        )}
+        {heroSub && heroSub !== heroLead && (
+          <p className="mt-2 text-[15px] leading-relaxed text-muted">{heroSub}</p>
         )}
 
-        {/* CTA */}
-        {(project.url || project.liveUrl) && (
-          <div className="mt-6 flex flex-wrap gap-3">
-            {project.liveUrl && (
-              <a
-                href={project.liveUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-              >
-                라이브 데모 ↗
-              </a>
-            )}
-            {project.url && (
-              <a
-                href={project.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-lg border border-line px-4 py-2 text-sm font-medium text-fg transition-colors hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
-              >
-                Repository ↗
-              </a>
-            )}
-          </div>
-        )}
+        {!multi && lead && <Cta e={lead} />}
       </header>
 
-      {/* At-a-glance 메타 */}
-      {hasMeta && (
-        <dl className="mt-8 grid grid-cols-1 gap-x-8 gap-y-4 rounded-xl border border-line bg-surface p-5 sm:grid-cols-2">
-          {metaRows.map((r) => (
-            <div key={r.label} className="flex flex-col gap-0.5">
-              <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">
-                {r.label}
-              </dt>
-              <dd className="text-sm text-fg">{r.value}</dd>
+      {multi ? (
+        <>
+          {/* 대분류 종합 메타 */}
+          <dl className="mt-8 grid grid-cols-1 gap-x-8 gap-y-4 rounded-xl border border-line bg-surface p-5 sm:grid-cols-2">
+            {groupPeriod && (
+              <div className="flex flex-col gap-0.5">
+                <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">기간</dt>
+                <dd className="text-sm text-fg">{groupPeriod}</dd>
+              </div>
+            )}
+            <div className="flex flex-col gap-0.5">
+              <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">경험</dt>
+              <dd className="text-sm text-fg">{group.count}건</dd>
             </div>
-          ))}
-          {project.tags.length > 0 && (
-            <div className="flex flex-col gap-1.5 sm:col-span-2">
-              <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">스택</dt>
-              <dd className="flex flex-wrap gap-1.5">
-                {project.tags.map((t) => (
-                  <span key={t.id} className="chip">
-                    {t.name}
-                  </span>
-                ))}
-              </dd>
-            </div>
-          )}
-        </dl>
-      )}
+            {group.tags.length > 0 && (
+              <div className="flex flex-col gap-1.5 sm:col-span-2">
+                <dt className="font-mono text-[11px] uppercase tracking-widest text-muted">스택</dt>
+                <dd className="flex flex-wrap gap-1.5">
+                  {group.tags.map((t) => (
+                    <span key={t.id} className="chip">
+                      {t.name}
+                    </span>
+                  ))}
+                </dd>
+              </div>
+            )}
+          </dl>
 
-      {/* 케이스스터디 본문 */}
-      {body.length > 0 && (
-        <div className="mt-10 border-t border-line pt-2">
-          <PostBody blocks={body} />
-        </div>
+          {/* 경험 스택 */}
+          {group.experiences.map((e, i) => (
+            <section key={e.id} className="mt-12 border-t border-line pt-8">
+              <p className="font-mono text-xs uppercase tracking-widest text-accent">
+                경험 {i + 1}
+              </p>
+              <h2 className="mt-2 text-2xl font-bold tracking-tight text-fg">{e.projectName}</h2>
+              {e.impact?.trim() && (
+                <p className="mt-3 text-[15px] font-medium leading-relaxed text-fg">
+                  {e.impact.trim()}
+                </p>
+              )}
+              {e.description?.trim() && e.description.trim() !== e.impact?.trim() && (
+                <p className="mt-2 text-sm leading-relaxed text-muted">{e.description.trim()}</p>
+              )}
+              <ExperienceMeta e={e} />
+              <Cta e={e} />
+              {e.body && e.body.length > 0 && (
+                <div className="mt-8">
+                  <PostBody blocks={e.body} />
+                </div>
+              )}
+            </section>
+          ))}
+        </>
+      ) : (
+        lead && (
+          <>
+            <ExperienceMeta e={lead} />
+            {lead.body && lead.body.length > 0 && (
+              <div className="mt-10 border-t border-line pt-2">
+                <PostBody blocks={lead.body} />
+              </div>
+            )}
+          </>
+        )
       )}
 
       {/* Footer nav */}

--- a/app/(site)/projects/page.tsx
+++ b/app/(site)/projects/page.tsx
@@ -1,11 +1,11 @@
 import ProjectItem from "../../../components/projects/projectItem"
-import { getProjects } from "../../../lib/notion"
+import { getProjectGroups } from "../../../lib/notion"
 
 export const metadata = { title: "Projects" }
 export const revalidate = 3600
 
 export default async function Projects() {
-  const ProjectArr = await getProjects()
+  const groups = await getProjectGroups()
 
   return (
     <>
@@ -13,16 +13,16 @@ export default async function Projects() {
         <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Projects</p>
         <h1 className="mt-3 text-3xl font-bold tracking-tight text-fg sm:text-4xl">프로젝트</h1>
         <p className="mt-3 text-[15px] leading-relaxed text-muted">
-          {ProjectArr.length > 0
-            ? `총 ${ProjectArr.length}개의 프로젝트`
+          {groups.length > 0
+            ? `총 ${groups.length}개의 프로젝트`
             : "프로젝트 데이터를 불러오는 중입니다."}
         </p>
       </header>
 
-      {ProjectArr.length > 0 ? (
+      {groups.length > 0 ? (
         <div className="gap-8 sm:columns-2 xl:columns-3">
-          {ProjectArr.map((item) => (
-            <ProjectItem key={item.id} data={item} />
+          {groups.map((g) => (
+            <ProjectItem key={g.slug} data={g} />
           ))}
         </div>
       ) : (

--- a/components/projects/projectItem.tsx
+++ b/components/projects/projectItem.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link"
 import Image from "next/image"
+import type { Block } from "../../lib/posts"
 
 export interface ProjectTag {
   id: string;
   name: string;
 }
 
-export interface Project {
+// 하나의 "경험/기여"(Notion 행 1개). 여러 경험이 하나의 대분류 프로젝트로 묶인다.
+export interface Experience {
   id: string;
   projectName: string;
   description: string;
@@ -21,6 +23,32 @@ export interface Project {
   role?: string;
   teamSize?: string;
   liveUrl?: string;
+  // 대분류(프로젝트) 그룹핑. group 미설정 시 이 경험이 독립 프로젝트가 된다.
+  group?: string;
+  groupSummary?: string;
+  // 상세 페이지에서 채워지는 본문 블록.
+  body?: Block[];
+}
+
+// 대분류(실제 프로젝트). 경험 여러 개를 묶는다.
+export interface ProjectGroup {
+  slug: string;
+  name: string;
+  summary: string;
+  cover: string;
+  tags: ProjectTag[];
+  startDate: string;
+  endDate: string;
+  inProgress: boolean;
+  count: number;
+  experiences: Experience[];
+}
+
+// "2024-09-01" / "2024.09" → "2024.09"
+function fmt(d?: string) {
+  if (!d) return "";
+  const [y, m] = d.replace(/\./g, "-").split("-");
+  return m ? `${y}.${m}` : y;
 }
 
 const cardClass =
@@ -28,17 +56,16 @@ const cardClass =
   "hover:border-accent/60 hover:bg-surface-hover motion-safe:hover:-translate-y-0.5 " +
   "focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30";
 
-export default function ProjectItem({ data }: { data: Project }) {
-  const glyph = Array.from(data.projectName)[0] ?? "·";
+// 대분류(프로젝트) 카드. 목록/홈 공용.
+export default function ProjectItem({ data }: { data: ProjectGroup }) {
+  const glyph = Array.from(data.name)[0] ?? "·";
   const firstTag = data.tags?.[0]?.name;
-  // status: true = Done, false = 진행 중
-  const inProgress = !data.status;
-  // 프로젝트명 기반 결정적 각도(해치 텍스처가 카드마다 조금씩 달라지도록)
+  const inProgress = data.inProgress;
   const hatchAngle =
-    (Array.from(data.projectName).reduce((sum, ch) => sum + ch.charCodeAt(0), 0) % 4) * 45;
+    (Array.from(data.name).reduce((sum, ch) => sum + ch.charCodeAt(0), 0) % 4) * 45;
 
   const hasPeriod = Boolean(data.startDate);
-  const period = `${data.startDate} — ${data.endDate || "현재"}`;
+  const period = `${fmt(data.startDate)} — ${data.inProgress ? "현재" : fmt(data.endDate) || "현재"}`;
 
   const body = (
     <>
@@ -50,8 +77,6 @@ export default function ProjectItem({ data }: { data: Project }) {
             alt=""
             fill
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            // Notion 커버 호스트(app.notion.com 등)가 remotePatterns 밖이면 최적화기가 400.
-            // 커버는 임의 호스트라 unoptimized 로 원본 서빙(어떤 호스트든 표시 보장). lazy/레이아웃은 유지.
             unoptimized
             className="object-cover grayscale-[15%] opacity-95 transition group-hover:grayscale-0 group-hover:opacity-100 motion-safe:group-hover:scale-[1.03]"
           />
@@ -81,12 +106,12 @@ export default function ProjectItem({ data }: { data: Project }) {
           >
             {inProgress ? "●" : "○"}
           </span>
-          <span className="line-clamp-1">{data.projectName}</span>
+          <span className="line-clamp-1">{data.name}</span>
         </h3>
 
-        {data.description && (
+        {data.summary && (
           <p className="mt-1.5 text-sm leading-relaxed text-muted line-clamp-2">
-            {data.description}
+            {data.summary}
           </p>
         )}
 
@@ -105,7 +130,10 @@ export default function ProjectItem({ data }: { data: Project }) {
 
         <div className="mt-auto flex items-center justify-between border-t border-line pt-4">
           <span className="font-mono text-xs text-muted">{hasPeriod ? period : ""}</span>
-          <span className="text-sm text-accent group-hover:text-accent-hover">
+          <span className="flex items-center gap-2 text-sm text-accent group-hover:text-accent-hover">
+            {data.count > 1 && (
+              <span className="font-mono text-xs text-muted">경험 {data.count}</span>
+            )}
             자세히 →
           </span>
         </div>
@@ -113,10 +141,8 @@ export default function ProjectItem({ data }: { data: Project }) {
     </>
   );
 
-  // 카드 전체를 프로젝트 상세 페이지 링크로(케이스스터디). GitHub/live 링크는 상세에서 노출.
-  // 앵커 중첩을 피하기 위해 내부에는 별도의 <a>/<Link> 를 두지 않는다.
   return (
-    <Link href={`/projects/${data.id}`} className={cardClass}>
+    <Link href={`/projects/${data.slug}`} className={cardClass}>
       {body}
     </Link>
   );

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,6 +1,11 @@
-import type { Project } from "../components/projects/projectItem"
+import type {
+  Experience,
+  ProjectGroup,
+  ProjectTag,
+} from "../components/projects/projectItem"
 import { TOKEN, DATABASE_ID } from "../config"
-import { fallbackProjects } from "./projectsFallback"
+import { fallbackExperiences } from "./projectsFallback"
+import { fetchBody } from "./postsData"
 
 // Notion query 응답 중 실제로 사용하는 필드만 최소한으로 정의
 interface NotionText {
@@ -21,6 +26,8 @@ interface NotionProperties {
   role?: { rich_text?: NotionText[] }
   teamSize?: { rich_text?: NotionText[] }
   liveUrl?: { url?: string }
+  group?: { select?: { name?: string } }
+  groupSummary?: { rich_text?: NotionText[] }
 }
 interface NotionPage {
   id: string
@@ -31,7 +38,7 @@ interface NotionQueryResponse {
   results?: NotionPage[]
 }
 
-function mapProject(data: NotionPage): Project {
+function mapExperience(data: NotionPage): Experience {
   const p = data.properties || {}
   return {
     id: data.id,
@@ -47,7 +54,84 @@ function mapProject(data: NotionPage): Project {
     role: p.role?.rich_text?.[0]?.plain_text ?? "",
     teamSize: p.teamSize?.rich_text?.[0]?.plain_text ?? "",
     liveUrl: p.liveUrl?.url || "",
+    group: p.group?.select?.name ?? "",
+    groupSummary: p.groupSummary?.rich_text?.[0]?.plain_text ?? "",
   }
+}
+
+// 대분류 이름 → 깔끔한 ascii slug. 미등록 그룹은 인코딩으로 폴백.
+const GROUP_SLUGS: Record<string, string> = {
+  "CloudHospital.Api 백엔드": "cloudhospital-api",
+  "Omni 메시징 백엔드": "omni",
+  "EhrApi 이벤트 백엔드": "ehrapi",
+}
+function groupSlug(name: string): string {
+  return GROUP_SLUGS[name] ?? encodeURIComponent(name)
+}
+
+function normDate(s?: string): string {
+  return (s || "").replace(/\./g, "-")
+}
+
+// 경험 목록을 대분류(프로젝트) 그룹으로 묶는다.
+// group 이 있으면 같은 group 끼리, 없으면 그 경험이 독립 프로젝트가 된다.
+function buildGroups(exps: Experience[]): ProjectGroup[] {
+  const map = new Map<string, Experience[]>()
+  const order: string[] = []
+  for (const e of exps) {
+    const key = e.group ? `g:${e.group}` : `s:${e.id}`
+    if (!map.has(key)) {
+      map.set(key, [])
+      order.push(key)
+    }
+    map.get(key)!.push(e)
+  }
+
+  const groups: ProjectGroup[] = order.map((key) => {
+    const items = map.get(key)!
+    // 경험은 최신 시작일 순으로
+    items.sort((a, b) => normDate(b.startDate).localeCompare(normDate(a.startDate)))
+    const grouped = key.startsWith("g:")
+    const name = grouped ? items[0].group! : items[0].projectName
+    const slug = grouped ? groupSlug(items[0].group!) : items[0].id
+    const summary =
+      items.find((e) => e.groupSummary?.trim())?.groupSummary?.trim() ||
+      (items.length === 1 ? items[0].description : "")
+
+    // 태그 union (이름 기준 dedupe)
+    const tags: ProjectTag[] = []
+    const seen = new Set<string>()
+    for (const e of items) {
+      for (const t of e.tags) {
+        if (!seen.has(t.name)) {
+          seen.add(t.name)
+          tags.push(t)
+        }
+      }
+    }
+
+    const starts = items.map((e) => normDate(e.startDate)).filter(Boolean).sort()
+    const ends = items.map((e) => normDate(e.endDate)).filter(Boolean).sort()
+    const inProgress = items.some((e) => !e.status)
+    const cover = items.find((e) => e.cover)?.cover || ""
+
+    return {
+      slug,
+      name,
+      summary,
+      cover,
+      tags,
+      startDate: starts[0] || "",
+      endDate: inProgress ? "" : ends[ends.length - 1] || "",
+      inProgress,
+      count: items.length,
+      experiences: items,
+    }
+  })
+
+  // 대분류는 최신 시작일 순으로(최근 백엔드 프로젝트가 먼저)
+  groups.sort((a, b) => normDate(b.startDate).localeCompare(normDate(a.startDate)))
+  return groups
 }
 
 function notionHeaders() {
@@ -59,20 +143,15 @@ function notionHeaders() {
   }
 }
 
-export async function getProjects(): Promise<Project[]> {
-  // 토큰/DB가 없거나 요청이 실패해도 빌드가 깨지지 않도록 방어적으로 처리
+// 라이브 Notion 경험(행) 전체. 토큰/DB 미설정·실패·빈 결과면 fallback.
+async function getExperiences(): Promise<Experience[]> {
   if (!TOKEN || !DATABASE_ID) {
-    return fallbackProjects
+    return fallbackExperiences
   }
 
   const options = {
     method: "POST",
-    headers: {
-      accept: "application/json",
-      "Notion-Version": "2022-06-28",
-      "content-type": "application/json",
-      Authorization: `Bearer ${TOKEN}`,
-    },
+    headers: notionHeaders(),
     body: JSON.stringify({
       sorts: [{ property: "projectName", direction: "ascending" }],
       page_size: 100,
@@ -86,38 +165,37 @@ export async function getProjects(): Promise<Project[]> {
       options
     )
     if (!res.ok) throw new Error(`Notion API ${res.status}`)
-    const projects = (await res.json()) as NotionQueryResponse
-
-    const ProjectArr: Project[] = (projects.results || []).map(mapProject)
-
-    // 결과가 비어 있으면 큐레이션된 대체 목록으로 폴백
-    if (ProjectArr.length === 0) {
-      return fallbackProjects
-    }
-
-    return ProjectArr
+    const data = (await res.json()) as NotionQueryResponse
+    const exps = (data.results || []).map(mapExperience)
+    if (exps.length === 0) return fallbackExperiences
+    return exps
   } catch (e) {
     console.error("[projects] Notion fetch failed:", (e as Error).message)
-    return fallbackProjects
+    return fallbackExperiences
   }
 }
 
-// 단건 프로젝트(상세 페이지용). Notion 미설정/실패/미발견 시 fallback 에서 조회.
-export async function getProject(id: string): Promise<Project | null> {
-  if (TOKEN && DATABASE_ID) {
-    try {
-      const res = await fetch(`https://api.notion.com/v1/pages/${id}`, {
-        headers: notionHeaders(),
-        next: { revalidate: 3600 },
-      })
-      if (res.ok) {
-        const page = (await res.json()) as NotionPage
-        const proj = mapProject(page)
-        if (proj.projectName) return proj
+// 목록/홈용: 대분류(프로젝트) 그룹 목록 (본문 미포함).
+export async function getProjectGroups(): Promise<ProjectGroup[]> {
+  const exps = await getExperiences()
+  return buildGroups(exps)
+}
+
+// 상세용: slug 로 대분류 1건 + 각 경험의 본문을 채워서 반환.
+export async function getProjectGroup(
+  slug: string
+): Promise<ProjectGroup | null> {
+  const groups = await getProjectGroups()
+  const group = groups.find((g) => g.slug === slug)
+  if (!group) return null
+  await Promise.all(
+    group.experiences.map(async (e) => {
+      try {
+        e.body = await fetchBody(e.id)
+      } catch {
+        e.body = []
       }
-    } catch (e) {
-      console.error("[project] Notion fetch failed:", (e as Error).message)
-    }
-  }
-  return fallbackProjects.find((p) => p.id === id) ?? null
+    })
+  )
+  return group
 }

--- a/lib/projectsFallback.ts
+++ b/lib/projectsFallback.ts
@@ -1,8 +1,19 @@
-import type { Project } from "../components/projects/projectItem"
+import type { Experience } from "../components/projects/projectItem"
 
-// Notion 연동이 비어 있을 때 사용하는 큐레이션된 대체 프로젝트 목록.
+// Notion 연동이 비어 있을 때 사용하는 큐레이션된 대체 경험 목록.
 // site/resume에 이미 존재하는 사실만 사용하고, 새로운 지표는 만들지 않는다.
-export const fallbackProjects: Project[] = [
+// group 으로 대분류(프로젝트) 묶음이 결정된다(라이브 Notion과 동일 구조).
+const CH_API = "CloudHospital.Api 백엔드"
+const OMNI = "Omni 메시징 백엔드"
+const EHRAPI = "EhrApi 이벤트 백엔드"
+const CH_API_SUMMARY =
+  "병원 SaaS 플랫폼의 .NET 백엔드 — API 성능, HTTP 복원력, passwordless 인증 전반에 걸친 기여."
+const OMNI_SUMMARY =
+  "SignalR 이벤트 엔진에서 출발해 독립 플랫폼으로 재구축한 멀티채널(WhatsApp·LINE·WeChat) 메시징 백엔드."
+const EHRAPI_SUMMARY =
+  "MassTransit/RabbitMQ 이벤트 아키텍처와 멀티테넌시를 적용한 병원 EHR 백엔드."
+
+export const fallbackExperiences: Experience[] = [
   {
     id: "omni-messaging-backend",
     projectName: "멀티플랫폼 채팅/메시징 백엔드 (Omni)",
@@ -20,6 +31,11 @@ export const fallbackProjects: Project[] = [
     startDate: "2024.09",
     endDate: "",
     status: false,
+    impact:
+      "실시간 메시지 파이프라인 병목 제거 — 매니저 조회 147ms→4ms(−97%), broadcast 실시간 알림 누락을 커밋-전-발행 레이스까지 추적해 수정",
+    role: "백엔드 설계·구현 오너십 — SignalR 알림 체인, 트랜잭션 커밋-후 이벤트 발행 인터셉터, 송수신 latency 계측·최적화",
+    group: OMNI,
+    groupSummary: OMNI_SUMMARY,
   },
   {
     id: "ef-core-query-optimization",
@@ -36,6 +52,11 @@ export const fallbackProjects: Project[] = [
     startDate: "2026.05",
     endDate: "2026.07",
     status: true,
+    impact:
+      "GET /hospitals 91초→0.04초(약 2000배) — Include+ProjectTo가 만든 1.38억 rows 카테시안 폭발을 AsSplitQuery로 해소",
+    role: "prd 타임아웃(103건) 근본 원인 분석·쿼리 최적화 — 로컬 SQL 실측으로 페이로드 MD5 동일성·회귀 zero 검증",
+    group: CH_API,
+    groupSummary: CH_API_SUMMARY,
   },
   {
     id: "polly-http-resilience",
@@ -52,6 +73,11 @@ export const fallbackProjects: Project[] = [
     startDate: "2026.06",
     endDate: "2026.06",
     status: true,
+    impact:
+      "일시적 네트워크·5xx 실패로 쌓인 자동 버그 보고 333건의 근본 원인을 Polly 재시도(지수 백오프)+AD 토큰 캐싱으로 제거",
+    role: "솔루션 전반의 HTTP 복원력 계층 신규 설계·도입 — 공통 Polly 정책, 토큰 캐시(Singleton), silent failure 제거",
+    group: CH_API,
+    groupSummary: CH_API_SUMMARY,
   },
   {
     id: "sms-ciba-authentication",
@@ -68,6 +94,11 @@ export const fallbackProjects: Project[] = [
     startDate: "2025.01",
     endDate: "2025.03",
     status: true,
+    impact:
+      "CIBA 기반 passwordless OTP 로그인을 IdentityServer에 통합 — OTP 재전송 레이트 리미팅으로 남용 방지",
+    role: "CIBA OTP 인증 흐름 통합 및 재전송 레이트 리미팅 구현 (IdentityServer STS)",
+    group: CH_API,
+    groupSummary: CH_API_SUMMARY,
   },
   {
     id: "ehrapi-event-driven-backend",
@@ -85,5 +116,10 @@ export const fallbackProjects: Project[] = [
     startDate: "2022.01",
     endDate: "2024.08",
     status: true,
+    impact:
+      "이벤트 기반(MassTransit/RabbitMQ) EHR 백엔드 — 발행·SignalR 알림·멀티테넌트 격리, E2E Epic 100%·테스트 999/999 통과",
+    role: "Integration Event 발행 배관·SignalR 실시간 알림 consumer·2단계 RBAC 테넌트 격리 구현 및 테스트",
+    group: EHRAPI,
+    groupSummary: EHRAPI_SUMMARY,
   },
 ]


### PR DESCRIPTION
Closes #70

## 배경
기존 프로젝트 목록은 하나의 플랫폼과 그 안의 단발 작업이 같은 급의 카드로 나란히 노출돼, 규모가 다른 항목이 동일 레벨로 보이는 문제가 있었다.

## 변경
- **데이터 모델**: `Experience`(경험 1건) + `ProjectGroup`(대분류) 도입. `group` 필드로 묶고, 미설정 경험은 독립 프로젝트가 된다.
- **목록/홈**: 대분류당 카드 1개로 집약(여러 경험이 묶인 경우 경험 수 표시).
- **상세**: 대분류 개요 + 종합 메타(기간·스택·경험 수) + 소속 경험을 섹션으로 스택(각 경험 = 임팩트 + 문제/접근/아키텍처/결과). 단일 경험 프로젝트는 경험 1건 레이아웃으로 자연 폴백.
- **라우팅/메타데이터**: 정적 파라미터·canonical·OpenGraph를 대분류 slug(`cloudhospital-api`·`omni`·`ehrapi` 등) 단위로 갱신.
- **fallback**: Notion 미연동 시 대체 데이터도 동일 그룹 구조로 정비.

## 데이터
프로젝트 데이터의 `group`/`groupSummary` 필드는 CMS(Notion)에 이미 설정 완료. 백엔드 경험 5건이 3개 대분류로 묶인다:
- **CloudHospital.Api 백엔드** — EF Core 최적화 · HTTP 복원력(Polly) · CIBA 인증
- **Omni 메시징 백엔드**
- **EhrApi 이벤트 백엔드**
- (기존 프론트/SI 7건은 각각 독립 프로젝트로 유지)

## 검증
- 워크트리에서 `next lint`(신규 경고 없음), `next build` 통과.
- 그룹 slug 정적 생성 확인(cloudhospital-api/omni/ehrapi).

## 반영 참고
목록/상세 ISR 1시간. 새 대분류 상세 URL은 프로덕션 배포 후 확정 생성.