### PR TITLE
feat: 모바일 헤더/햄버거 내비게이션 추가

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,9 +1,11 @@
 import Sidebar from "../../components/sidebar"
+import MobileHeader from "../../components/mobileHeader"
 import Footer from "../../components/footer"
 
 export default function SiteLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="mx-auto max-w-[1240px] px-6">
+      <MobileHeader />
       <div className="md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-14">
         <Sidebar />
         <main className="min-w-0 py-10 md:py-14">{children}</main>

--- a/components/mobileHeader.tsx
+++ b/components/mobileHeader.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { useEffect, useState } from "react"
+import { NAV, isNavActive } from "../lib/nav"
+import DarkModeToggleBtn from "./darkModeToggleBtn"
+
+// 모바일(md 미만) 전용 상단 바 + 햄버거 드로어.
+// 데스크톱에서는 렌더 자체를 숨긴다(md:hidden). 사이드바가 데스크톱을 담당.
+export default function MobileHeader() {
+  const pathname = usePathname()
+  const [open, setOpen] = useState(false)
+
+  // 라우트 변경 시 닫기
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
+  // 열렸을 때: body 스크롤 잠금 + Esc 로 닫기
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false)
+    }
+    document.addEventListener("keydown", onKey)
+    const prev = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => {
+      document.removeEventListener("keydown", onKey)
+      document.body.style.overflow = prev
+    }
+  }, [open])
+
+  return (
+    <div className="md:hidden">
+      {/* 상단 바 */}
+      <header className="sticky top-0 z-40 flex items-center justify-between border-b border-line bg-page/90 py-3 backdrop-blur">
+        <Link href="/" aria-label="home" className="flex items-center gap-2">
+          <span className="flex h-7 w-7 items-center justify-center bg-accent text-[11px] font-extrabold text-white">
+            SO
+          </span>
+          <span className="text-sm font-bold tracking-wide text-fg">SEJUNE OH</span>
+        </Link>
+        <div className="flex items-center gap-1">
+          <DarkModeToggleBtn />
+          <button
+            type="button"
+            aria-label={open ? "메뉴 닫기" : "메뉴 열기"}
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md text-fg transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
+          >
+            {open ? (
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M6 6l12 12M18 6L6 18" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M4 7h16M4 12h16M4 17h16" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </header>
+
+      {/* 드로어 오버레이 */}
+      {open && (
+        <div className="fixed inset-0 z-50">
+          <button
+            type="button"
+            aria-label="메뉴 닫기"
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setOpen(false)}
+          />
+          <nav className="absolute right-0 top-0 flex h-full w-72 max-w-[80%] flex-col border-l border-line bg-page p-6 shadow-xl">
+            <span className="mb-4 font-mono text-xs uppercase tracking-widest text-muted">Menu</span>
+            {NAV.map((n) => (
+              <Link
+                key={n.href}
+                href={n.href}
+                className={`py-2 text-lg font-bold tracking-wide transition-colors ${
+                  isNavActive(pathname, n.href) ? "text-accent" : "text-fg hover:text-accent"
+                }`}
+              >
+                {n.label}
+              </Link>
+            ))}
+            <div className="mt-auto space-y-1.5 border-t border-line pt-4 text-[13px] leading-relaxed text-muted">
+              <p>Email. etry0715@gmail.com</p>
+              <p>GitHub. github.com/SejuneOh</p>
+              <p>Location. Seoul, Korea</p>
+            </div>
+          </nav>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -3,14 +3,7 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import DarkModeToggleBtn from "./darkModeToggleBtn"
-
-const nav = [
-  { href: "/", label: "HOME" },
-  { href: "/projects", label: "PROJECTS" },
-  { href: "/blog", label: "BLOG" },
-  { href: "/resume", label: "RESUME" },
-  { href: "/contact", label: "CONTACT" },
-]
+import { NAV, isNavActive } from "../lib/nav"
 
 function GitHubIcon() {
   return (
@@ -20,13 +13,12 @@ function GitHubIcon() {
   )
 }
 
+// 데스크톱(md+) 전용 사이드바. 모바일은 MobileHeader 가 담당.
 export default function Sidebar() {
   const pathname = usePathname()
-  const isActive = (href: string) =>
-    href === "/" ? pathname === "/" : pathname.startsWith(href)
 
   return (
-    <aside className="py-10 md:sticky md:top-0 md:h-screen md:self-start md:overflow-y-auto">
+    <aside className="hidden py-10 md:block md:sticky md:top-0 md:h-screen md:self-start md:overflow-y-auto">
       {/* Brand block */}
       <Link href="/" aria-label="home" className="inline-block">
         <div className="relative flex h-36 w-36 flex-col justify-between bg-accent p-4 text-white">
@@ -42,12 +34,12 @@ export default function Sidebar() {
 
       {/* Vertical nav */}
       <nav className="mt-9 flex flex-col gap-2.5">
-        {nav.map((n) => (
+        {NAV.map((n) => (
           <Link
             key={n.href}
             href={n.href}
             className={`w-fit text-lg font-bold tracking-wide transition-colors ${
-              isActive(n.href) ? "text-accent" : "text-fg hover:text-accent"
+              isNavActive(pathname, n.href) ? "text-accent" : "text-fg hover:text-accent"
             }`}
           >
             {n.label}

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -1,0 +1,18 @@
+// 사이드바(데스크톱)와 모바일 헤더가 공유하는 주 내비 항목.
+export interface NavItem {
+  href: string
+  label: string
+}
+
+export const NAV: NavItem[] = [
+  { href: "/", label: "HOME" },
+  { href: "/projects", label: "PROJECTS" },
+  { href: "/blog", label: "BLOG" },
+  { href: "/resume", label: "RESUME" },
+  { href: "/contact", label: "CONTACT" },
+]
+
+// 활성 경로 판정(홈은 정확히 일치, 그 외는 prefix).
+export function isNavActive(pathname: string, href: string): boolean {
+  return href === "/" ? pathname === "/" : pathname.startsWith(href)
+}


### PR DESCRIPTION
Closes #73

## 배경
모바일(md 미만)에서 사이드바가 콘텐츠 위에 통째로 쌓여(브랜드+내비+연락처+소셜) 본문을 화면 아래로 크게 밀어냈다. 첫 화면에서 콘텐츠가 바로 보이지 않는 UX 문제.

## 변경
- **MobileHeader**(신규, 클라이언트): 모바일 전용 sticky 상단 바(브랜드 축약 + 테마 토글 + 햄버거). 햄버거 → 우측 슬라이드 드로어(내비 링크 + 연락처). 라우트 변경·Esc·백드롭 클릭 시 닫힘, 열렸을 때 body 스크롤 잠금, `aria-expanded`/aria-label 부여.
- **Sidebar**: 데스크톱(md+) 전용으로 전환(`hidden md:block`).
- **lib/nav.ts**(신규): 내비 항목·활성 판정을 공용 모듈로 추출 → 사이드바·모바일 헤더 공유(중복 제거).

## 검증
- `next lint`(신규 경고 없음), `next build` 통과.
- 데스크톱 레이아웃(2-col 그리드)은 불변.