### PR TITLE
feat: 블로그 글별 동적 OG 이미지 (트랙 A 마무리)

### DIFF
--- a/app/(site)/blog/[slug]/opengraph-image.tsx
+++ b/app/(site)/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,81 @@
+import { ImageResponse } from "next/og"
+import { getPost } from "../../../../lib/postsData"
+import { SITE_URL, SITE_NAME } from "../../../../lib/site"
+
+// 블로그 글별 동적 OG 이미지(링크 공유 카드).
+// 제목이 한국어일 수 있어 Noto Sans KR 을 "필요한 글자만" 서브셋으로 임베드한다
+// (Google Fonts CSS 의 text= 파라미터 → woff2 서브셋). 실패 시 폰트 없이 폴백.
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+export const alt = "Sejune Oh — Blog"
+export const runtime = "edge"
+
+async function loadKoreanFont(text: string): Promise<ArrayBuffer | null> {
+  try {
+    const api = `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@700&text=${encodeURIComponent(text)}`
+    const css = await fetch(api, {
+      headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" },
+    }).then((r) => r.text())
+    const url = css.match(/src:\s*url\(([^)]+)\)\s*format/)?.[1]
+    if (!url) return null
+    return await fetch(url).then((r) => r.arrayBuffer())
+  } catch {
+    return null
+  }
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const post = await getPost(slug)
+  const title = post?.title || SITE_NAME
+  const eyebrow = "BLOG"
+  const domain = SITE_URL.replace(/^https?:\/\//, "")
+  const footer = `${SITE_NAME} · ${domain}`
+
+  // 렌더되는 모든 문자열을 합쳐 서브셋 요청(라틴+한글 모두 포함).
+  const fontData = await loadKoreanFont(`${title}${eyebrow}${footer}·—`)
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background: "#191919",
+          color: "#ffffff",
+          fontFamily: fontData ? "Noto Sans KR" : "sans-serif",
+        }}
+      >
+        <div style={{ fontSize: 28, letterSpacing: 6, color: "#818cf8", textTransform: "uppercase" }}>
+          {eyebrow}
+        </div>
+        <div
+          style={{
+            fontSize: 62,
+            fontWeight: 700,
+            marginTop: 24,
+            lineHeight: 1.15,
+            display: "flex",
+          }}
+        >
+          {title}
+        </div>
+        <div style={{ fontSize: 26, color: "#9b9a97", marginTop: "auto" }}>{footer}</div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: fontData
+        ? [{ name: "Noto Sans KR", data: fontData, weight: 700 as const, style: "normal" as const }]
+        : undefined,
+    }
+  )
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -24,7 +24,7 @@ export default function OpengraphImage() {
           color: "#ffffff",
         }}
       >
-        <div style={{ fontSize: 28, letterSpacing: 8, color: "#2383e2", textTransform: "uppercase" }}>
+        <div style={{ fontSize: 28, letterSpacing: 8, color: "#818cf8", textTransform: "uppercase" }}>
           Backend Engineer · Fullstack
         </div>
         <div style={{ fontSize: 92, fontWeight: 800, marginTop: 24, lineHeight: 1.05 }}>Sejune Oh</div>


### PR DESCRIPTION
Closes #48

## 배경
트랙 A(SEO·노출·성능)의 대부분(sitemap·robots·metadataBase·openGraph·twitter·canonical·Person/BlogPosting JSON-LD·이미지 remotePatterns+next/image)은 이미 반영돼 있었다. **미구현으로 남은 유일한 항목**이 글별 동적 OG 이미지였다(한국어 제목 렌더용 CJK 폰트 임베드가 필요해 보류됐던 부분).

## 변경
- **app/(site)/blog/[slug]/opengraph-image.tsx** 신규: 글 제목 기반 1200×630 OG 카드. 한국어 제목은 **Noto Sans KR 서브셋**(Google Fonts `text=` 파라미터로 필요한 글자만 woff2 다운로드)으로 임베드. 폰트 로드 실패 시 폰트 없이 폴백(크래시 없음).
- **app/opengraph-image.tsx**: 사이트 기본 OG accent를 인디고(#818cf8)로 통일.

## 검증
- `next lint`(신규 경고 없음), `next build` 통과 — `/blog/[slug]/opengraph-image` 라우트 생성 확인.
- 배포 후: 글 링크 unfurl 시 제목이 들어간 OG 카드 노출(한글 정상 렌더) 확인 권장.

## 참고
A-3의 '이력서 폰트 next/font'는 이력서 아이덴티티 정합 이슈(#81)로 분리 추적.