### PR TITLE
사이트 라우트에 error·loading 바운더리 추가

### DIFF
--- a/app/(site)/error.tsx
+++ b/app/(site)/error.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+
+export default function SiteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // 서버/렌더 예외를 콘솔에 남겨 디버깅을 돕는다.
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center py-16 text-center">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-accent">Error</p>
+      <h1 className="mt-4 text-2xl font-bold tracking-tight text-fg sm:text-3xl">
+        문제가 발생했습니다
+      </h1>
+      <p className="mt-3 max-w-md text-[15px] leading-relaxed text-muted">
+        페이지를 불러오는 중 오류가 났어요. 잠시 후 다시 시도해 주세요.
+      </p>
+      <div className="mt-7 flex flex-wrap items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="inline-flex items-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          다시 시도
+        </button>
+        <Link
+          href="/"
+          className="inline-flex items-center rounded-lg border border-line px-4 py-2 text-sm font-medium text-fg transition-colors hover:bg-surface"
+        >
+          홈으로
+        </Link>
+      </div>
+      {error.digest && (
+        <p className="mt-6 font-mono text-[11px] text-muted/70">ref: {error.digest}</p>
+      )}
+    </div>
+  )
+}

--- a/app/(site)/loading.tsx
+++ b/app/(site)/loading.tsx
@@ -1,0 +1,18 @@
+// 사이트 라우트 로딩 스켈레톤 — 데이터 fetch 동안 빈 화면 대신 노출된다.
+export default function SiteLoading() {
+  return (
+    <div className="animate-pulse py-2" aria-hidden>
+      <div className="h-3 w-24 rounded bg-surface" />
+      <div className="mt-6 h-9 w-2/3 rounded-lg bg-surface" />
+      <div className="mt-4 h-4 w-full rounded bg-surface" />
+      <div className="mt-2.5 h-4 w-5/6 rounded bg-surface" />
+
+      <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-32 rounded-xl border border-line bg-surface" />
+        ))}
+      </div>
+      <span className="sr-only">불러오는 중…</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## 배경
사이트 라우트에 error/loading 바운더리가 없어, 서버 컴포넌트(콘텐츠 fetch 등)에서 예외가 나면 흰 화면이, 로딩 중엔 빈 화면이 그대로 노출될 수 있었습니다.

## 변경
- `app/(site)/error.tsx` — 렌더/서버 예외를 잡아 안내 문구 + **다시 시도**(reset)·**홈으로** 버튼을 보여주는 클라이언트 바운더리. 에러는 콘솔에 로깅하고, `digest`가 있으면 참조 코드로 노출.
- `app/(site)/loading.tsx` — 데이터를 불러오는 동안 흰 화면 대신 스켈레톤(제목·본문·카드 플레이스홀더)을 노출.
- 기존 사이트 톤(카드·accent·모노 레이블)과 시각적으로 일관되게 구성.

## 확인
- 하위 라우트에서 throw 시 흰 화면 대신 에러 UI 표시.
- 데이터 로딩 중 스켈레톤 노출.
- `next lint`(신규 경고 없음) + `next build` 통과.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)