### PR TITLE
on-demand revalidation: 콘텐츠 수정 즉시 반영

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { revalidatePath } from "next/cache"
+
+// Notion(CMS) 수정 후 목록·상세·홈을 재배포 없이 즉시 갱신하는 on-demand revalidation.
+//   호출 예:
+//     POST /api/revalidate?secret=XXX                 → 기본 경로 일괄 갱신
+//     POST /api/revalidate?secret=XXX&path=/projects/omni  → 특정 경로만 갱신(반복 가능)
+// 시크릿은 ?secret= 쿼리 또는 x-revalidate-secret 헤더로 전달한다.
+
+export const dynamic = "force-dynamic"
+
+// 콘텐츠 변경 시 함께 갱신할 기본 경로 + 동적 라우트 패턴.
+const DEFAULTS: Array<[string] | [string, "page" | "layout"]> = [
+  ["/"],
+  ["/projects"],
+  ["/projects/[id]", "page"],
+  ["/blog"],
+  ["/blog/[slug]", "page"],
+]
+
+function handle(req: NextRequest) {
+  const secret = process.env.REVALIDATE_SECRET
+  if (!secret) {
+    return NextResponse.json(
+      { ok: false, error: "REVALIDATE_SECRET 미설정" },
+      { status: 500 },
+    )
+  }
+
+  const provided =
+    req.nextUrl.searchParams.get("secret") ??
+    req.headers.get("x-revalidate-secret")
+  if (provided !== secret) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 })
+  }
+
+  const requested = req.nextUrl.searchParams.getAll("path").filter(Boolean)
+  let revalidated: string[]
+  if (requested.length > 0) {
+    // 지정 경로만 정밀 갱신(예: 수정된 프로젝트/글 상세).
+    requested.forEach((p) => revalidatePath(p))
+    revalidated = requested
+  } else {
+    // 미지정 시 콘텐츠 목록/홈/동적 상세를 일괄 갱신.
+    DEFAULTS.forEach(([p, type]) =>
+      type ? revalidatePath(p, type) : revalidatePath(p),
+    )
+    revalidated = DEFAULTS.map(([p]) => p)
+  }
+
+  return NextResponse.json({ ok: true, revalidated })
+}
+
+export async function POST(req: NextRequest) {
+  return handle(req)
+}
+
+export async function GET(req: NextRequest) {
+  return handle(req)
+}


### PR DESCRIPTION
## 배경
콘텐츠(프로젝트·글)를 CMS에서 수정해도 목록·상세·홈이 ISR(`revalidate=3600`) 때문에 최대 1시간 뒤에야 반영됐습니다. 수정 확인 흐름이 불편합니다.

## 변경
- `app/api/revalidate/route.ts` 신설:
  - 시크릿(`REVALIDATE_SECRET`)을 `?secret=` 쿼리 또는 `x-revalidate-secret` 헤더로 검증.
  - 경로 미지정 시 홈·`/projects`·`/blog` + 동적 상세(`/projects/[id]`, `/blog/[slug]`)를 일괄 갱신.
  - `?path=/projects/omni` 처럼 특정 경로만 정밀 갱신(반복 지정 가능).
  - 토큰 불일치/누락 → **401**, 시크릿 미설정 → 500.
  - `GET`/`POST` 모두 지원(자동화 웹훅·수동 트리거 겸용).

## 확인
- 토큰 있는 요청으로 호출 시 목록/상세가 재배포 없이 갱신.
- 토큰 없는 요청은 401.
- `next lint`(신규 경고 없음) + `next build` 통과, `/api/revalidate` 동적 라우트 생성 확인.

## 배포 시 필요 (오너)
- Vercel 환경변수 **`REVALIDATE_SECRET`** 설정(임의의 긴 무작위 문자열).
- 이후 CMS 자동화/수동으로 `POST https://<도메인>/api/revalidate?secret=<값>` 호출.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)