### PR TITLE
프로젝트 목록 레이아웃을 grid로 통일

### DIFF
--- a/app/(site)/projects/page.tsx
+++ b/app/(site)/projects/page.tsx
@@ -20,7 +20,7 @@ export default async function Projects() {
       </header>
 
       {groups.length > 0 ? (
-        <div className="gap-8 sm:columns-2 xl:columns-3">
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 xl:grid-cols-3">
           {groups.map((g) => (
             <ProjectItem key={g.slug} data={g} />
           ))}

--- a/components/projects/projectItem.tsx
+++ b/components/projects/projectItem.tsx
@@ -52,7 +52,7 @@ function fmt(d?: string) {
 }
 
 const cardClass =
-  "card group flex h-full flex-col overflow-hidden break-inside-avoid mb-8 " +
+  "card group flex h-full flex-col overflow-hidden " +
   "hover:border-accent/60 hover:bg-surface-hover motion-safe:hover:-translate-y-0.5 " +
   "focus-visible:border-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30";
 


### PR DESCRIPTION
## 배경
프로젝트 목록은 masonry(`columns-2 xl:columns-3`), 홈 프로젝트 인덱스는 grid를 써서 카드 정렬·간격이 페이지마다 달랐습니다.

## 변경
- `app/(site)/projects/page.tsx`: `sm:columns-2 xl:columns-3` → `grid grid-cols-1 gap-8 sm:grid-cols-2 xl:grid-cols-3`.
- `components/projects/projectItem.tsx`: 카드에서 masonry 전용 클래스(`break-inside-avoid`, `mb-8`) 제거 → grid 간격은 컨테이너 `gap`이 담당.
- 홈 인덱스는 이미 grid라 카드 변경만으로 양쪽이 동일한 정렬로 일치.

## 확인
- 목록·홈 카드 정렬/간격이 grid로 일치.
- 반응형: 모바일 1열 → 태블릿 2열 → 와이드 3열.
- `next lint`(신규 경고 없음) + `next build`(정적 15/15) 통과.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)