### PR TITLE
Dependabot로 의존성·GitHub Actions 자동 업데이트 등록

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot — 의존성 & GitHub Actions 자동 업데이트
+# PR은 feature→dev→main 플로에 맞춰 dev 브랜치를 타깃으로 생성한다.
+version: 2
+updates:
+  # npm 의존성 (루트)
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+    groups:
+      # minor/patch는 한 PR로 묶어 소음을 줄인다 (major는 개별 PR).
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions 워크플로
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## 배경
의존성(npm)과 GitHub Actions 버전을 수동으로 관리해, 보안 패치·업데이트가 누락되기 쉬웠습니다.

## 변경
- `.github/dependabot.yml` 추가:
  - **npm**(루트) + **github-actions** 에코시스템, 주간 스케줄.
  - PR 타깃 브랜치를 **dev**로 지정 → feature→dev→main 플로와 정합.
  - npm은 **minor/patch를 한 PR로 그룹핑**하고 open PR 상한을 5로 두어 소음 최소화(major는 개별 PR).
  - 목적별 라벨(`dependencies`/`ci`) + 커밋 prefix(`chore`/`ci`).

## 확인
- YAML 스키마 유효성 확인(version 2, 2개 에코시스템, target=dev).
- 병합 후 Dependabot이 dev 기준으로 업데이트 PR을 생성.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)