### PR TITLE
chore: ignore major dependency bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,19 @@ updates:
           - "minor"
           - "patch"
 
+    ignore:
+      # major 업그레이드는 breaking change라 자동 PR 대신 #102에서 수동 마이그레이션한다.
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
   # GitHub Actions 워크플로
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## What
Add `ignore` rules to `.github/dependabot.yml` so Dependabot stops opening **major-version** PRs for five packages that cannot build without a code/config migration:

- `next`
- `eslint-config-next`
- `eslint`
- `tailwindcss`
- `typescript`

## Why
Each of these majors ships breaking changes, so a plain version bump fails the Lint & Build check. Dependabot kept re-opening them, leaving the PR list perpetually red. Minor/patch and security updates for these packages continue to flow — only the major auto-PRs are suppressed.

## Scope
- No app code changes; config only.
- The deferred migrations are tracked in #102 and will be picked up as dedicated PRs.

Closes nothing; relates to #102.
