### PR TITLE
feat: add Vercel Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata, Viewport } from "next"
 import { Space_Grotesk } from "next/font/google"
 import Providers from "./providers"
 import { SITE_URL, SITE_NAME, SITE_TITLE, SITE_DESCRIPTION } from "../lib/site"
+import { Analytics } from "@vercel/analytics/next"
 
 // 제목용 디스플레이 폰트(라틴). --font-display 변수로 노출 → globals.css 헤딩에서 사용.
 const spaceGrotesk = Space_Grotesk({
@@ -49,6 +50,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ko" className={spaceGrotesk.variable} suppressHydrationWarning>
       <body>
         <Providers>{children}</Providers>
+        <Analytics />
       </body>
     </html>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portforlio_next",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "next": "^15.5.20",
         "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
@@ -1737,6 +1738,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "next": "^15.5.20",
     "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## What
Add [Vercel Analytics](https://vercel.com/docs/analytics) to the site.

- Install `@vercel/analytics`.
- Render `<Analytics />` once in the root layout (`app/layout.tsx`) so it loads on every route.

## Why
The site had no way to measure visitor traffic. Vercel Analytics is cookieless (no consent banner required) and needs no extra infrastructure since the app already deploys on Vercel.

## Verification
- `next lint` → no warnings or errors.
- `next build` → succeeds.
- After deploy to production, page views appear in the Vercel project's Analytics tab.

## Note
Analytics only collects data on Vercel production/preview deployments; local runs send nothing. No environment variables required.

Closes #83
