### PR TITLE
feat: add Cloudflare Turnstile to the contact form

### DIFF
--- a/app/(site)/contact/actions.ts
+++ b/app/(site)/contact/actions.ts
@@ -4,6 +4,7 @@ import { headers } from "next/headers"
 import { createInquiry, INQUIRY_TYPES } from "../../../lib/inquiries"
 import { notifyNewInquiry } from "../../../lib/notify"
 import { rateLimit } from "../../../lib/rateLimit"
+import { verifyTurnstile } from "../../../lib/turnstile"
 
 export interface ContactState {
   ok: boolean
@@ -26,6 +27,12 @@ export async function submitInquiry(
   const ip = h.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
   if (!rateLimit(`contact:${ip}`, 3, 10 * 60 * 1000)) {
     return { ok: false, message: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." }
+  }
+
+  // Turnstile(설정 시): 봇 캡차 토큰 검증. 키 미설정이면 verifyTurnstile 가 통과시킴.
+  const turnstileToken = String(formData.get("cf-turnstile-response") || "")
+  if (!(await verifyTurnstile(turnstileToken, ip === "unknown" ? undefined : ip))) {
+    return { ok: false, message: "봇 방지 확인에 실패했습니다. 새로고침 후 다시 시도해주세요." }
   }
 
   const name = String(formData.get("name") || "").trim()

--- a/components/contact/contactForm.tsx
+++ b/components/contact/contactForm.tsx
@@ -1,9 +1,13 @@
 "use client"
 
 import { useActionState } from "react"
+import Script from "next/script"
 import { submitInquiry, type ContactState } from "../../app/(site)/contact/actions"
 
 const INIT: ContactState = { ok: false, message: "" }
+
+// Turnstile 사이트 키가 있을 때만 위젯 렌더(없으면 폼은 그대로 동작).
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY
 
 // UI 옵션(서버 액션이 INQUIRY_TYPES 로 재검증). 서버 모듈을 client 로 끌어오지 않도록 여기서 정의.
 const TYPES = ["이메일 요청", "면접 요청"] as const
@@ -51,6 +55,21 @@ export default function ContactForm() {
         <span className={labelCls}>메시지 *</span>
         <textarea name="message" rows={6} required className={fieldCls} placeholder="문의 내용을 남겨주세요." />
       </label>
+
+      {TURNSTILE_SITE_KEY && (
+        <>
+          <Script
+            src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+            async
+            defer
+          />
+          <div
+            className="cf-turnstile"
+            data-sitekey={TURNSTILE_SITE_KEY}
+            data-theme="auto"
+          />
+        </>
+      )}
 
       <div>
         <button

--- a/lib/turnstile.ts
+++ b/lib/turnstile.ts
@@ -1,0 +1,22 @@
+// Cloudflare Turnstile 서버 검증. TURNSTILE_SECRET_KEY 미설정 시 검증을 건너뛴다
+// (키 없으면 기존 동작 유지 — notify.ts 와 동일한 graceful degrade 패턴).
+// 키가 설정된 경우에만 실제 방어가 활성화된다.
+export async function verifyTurnstile(token: string, ip?: string): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY
+  if (!secret) return true // 미설정 → skip
+  if (!token) return false
+  try {
+    const body = new URLSearchParams({ secret, response: token })
+    if (ip) body.set("remoteip", ip)
+    const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+    })
+    const data = (await res.json().catch(() => ({}))) as { success?: boolean }
+    return data.success === true
+  } catch (e) {
+    console.error("[turnstile] 검증 오류:", (e as Error).message)
+    return false // 검증 호출 실패 시 보수적으로 거부(키가 켜진 경우에만 도달)
+  }
+}


### PR DESCRIPTION
## What
Add a Cloudflare Turnstile (invisible CAPTCHA) layer to the public contact form, on top of the existing honeypot + in-memory rate limit.

- `lib/turnstile.ts` — server-side token verification against Cloudflare's `siteverify`.
- `app/(site)/contact/actions.ts` — verify the token after the honeypot and rate-limit checks.
- `components/contact/contactForm.tsx` — render the Turnstile widget and loader script.

## Graceful degradation (safe to ship now)
- The widget renders **only** when `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is set.
- The server verifies the token **only** when `TURNSTILE_SECRET_KEY` is set.
- With neither key present, the form behaves exactly as before — no visual change, no verification. Same pattern as the existing email-notify integration.

## Activation (owner)
Set two environment variables in Vercel from a Cloudflare Turnstile widget:
- `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (public site key)
- `TURNSTILE_SECRET_KEY` (secret)

## Verification
- `next lint` → no warnings or errors.
- `next build` → succeeds.
- No new npm dependencies (uses `fetch` + the hosted widget script).

## Out of scope (remain in #54)
- Durable rate limit (Upstash Redis / Vercel KV) to replace the per-instance in-memory limiter.
- Vercel Firewall/WAF dashboard rules.

Refs #54
