### PR TITLE
feat(admin): 프로젝트 CRUD + 문의 처리 상태 (#84)

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,33 +1,74 @@
 "use server"
 
 import { revalidatePath } from "next/cache"
-import { createProjectPage } from "../../lib/notionWrite"
+import {
+  createProjectPage,
+  updateProjectPage,
+  archiveProjectPage,
+} from "../../lib/notionWrite"
+import { setInquiryStatus } from "../../lib/inquiries"
 import { parseTags, requireOwner, type ActionState } from "../../lib/adminForm"
 
-export async function submitProject(
-  _prev: ActionState,
-  formData: FormData
-): Promise<ActionState> {
+function revalidateProjects() {
+  revalidatePath("/admin/projects")
+  revalidatePath("/projects", "layout") // 목록 + /projects/[id] 상세까지 갱신
+  revalidatePath("/")
+}
+
+// 생성/수정 겸용. hidden id 가 있으면 수정, 없으면 생성.
+// 이동은 클라이언트가 담당(성공/실패 UX·토스트 제어 위해 redirect 안 함).
+export async function saveProject(formData: FormData): Promise<ActionState> {
   const authError = await requireOwner()
   if (authError) return { ok: false, message: authError }
 
+  const id = String(formData.get("id") || "").trim()
   const name = String(formData.get("name") || "").trim()
   if (!name) return { ok: false, message: "프로젝트명은 필수입니다." }
 
+  const input = {
+    name,
+    description: String(formData.get("description") || "").trim(),
+    tags: parseTags(String(formData.get("tags") || "")),
+    github: String(formData.get("github") || "").trim(),
+    startDate: String(formData.get("startDate") || "").trim(),
+    endDate: String(formData.get("endDate") || "").trim(),
+    status: String(formData.get("status") || "").trim(),
+    impact: String(formData.get("impact") || "").trim(),
+    role: String(formData.get("role") || "").trim(),
+    teamSize: String(formData.get("teamSize") || "").trim(),
+    liveUrl: String(formData.get("liveUrl") || "").trim(),
+    group: String(formData.get("group") || "").trim(),
+    groupSummary: String(formData.get("groupSummary") || "").trim(),
+    cover: String(formData.get("cover") || "").trim(),
+    body: String(formData.get("body") || ""),
+  }
+
   try {
-    await createProjectPage({
-      name,
-      description: String(formData.get("description") || "").trim(),
-      tags: parseTags(String(formData.get("tags") || "")),
-      github: String(formData.get("github") || "").trim(),
-      startDate: String(formData.get("startDate") || "").trim(),
-      endDate: String(formData.get("endDate") || "").trim(),
-      status: String(formData.get("status") || "").trim(),
-    })
-    revalidatePath("/projects")
-    revalidatePath("/")
-    return { ok: true, message: `“${name}” 프로젝트를 Notion 에 등록했습니다.` }
+    if (id) {
+      // 본문이 실제로 바뀐 경우에만 블록 교체(다건 삭제·재생성). 아니면 속성만 갱신.
+      const originalBody = String(formData.get("originalBody") || "")
+      await updateProjectPage(id, input, input.body !== originalBody)
+    } else {
+      await createProjectPage(input)
+    }
   } catch (e) {
     return { ok: false, message: (e as Error).message }
   }
+
+  revalidateProjects()
+  return { ok: true, message: id ? "변경이 저장되었습니다." : `“${name}” 프로젝트를 등록했습니다.` }
+}
+
+export async function deleteProject(id: string): Promise<void> {
+  const authError = await requireOwner()
+  if (authError) throw new Error(authError)
+  await archiveProjectPage(id)
+  revalidateProjects()
+}
+
+export async function updateInquiryStatus(id: string, status: string): Promise<void> {
+  const authError = await requireOwner()
+  if (authError) throw new Error(authError)
+  await setInquiryStatus(id, status)
+  revalidatePath("/admin")
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 import { auth, signOut } from "@/auth"
-import ProjectForm from "../../components/admin/projectForm"
+import InquiryStatus from "../../components/admin/inquiryStatus"
 import { getInquiries } from "../../lib/inquiries"
 import { getAdminPosts } from "../../lib/postsData"
+import { getAdminProjects } from "../../lib/notion"
 
 // 검색엔진 비노출(민감 관리 페이지). 미들웨어가 접근 자체를 인증으로 막지만,
 // 색인/링크 노출도 이중으로 차단한다.
@@ -18,8 +19,13 @@ export const dynamic = "force-dynamic"
 export default async function AdminPage() {
   const session = await auth()
   const name = session?.user?.name ?? "관리자"
-  const [inquiries, posts] = await Promise.all([getInquiries(), getAdminPosts()])
+  const [inquiries, posts, projects] = await Promise.all([
+    getInquiries(),
+    getAdminPosts(),
+    getAdminProjects(),
+  ])
   const published = posts.filter((p) => p.published).length
+  const pending = inquiries.filter((q) => q.status !== "완료").length
 
   return (
     <main className="mx-auto max-w-[720px] px-6 py-16">
@@ -41,16 +47,25 @@ export default async function AdminPage() {
         <span className="text-accent">→</span>
       </Link>
 
-      {/* 프로젝트 등록 */}
-      <section className="mt-12">
-        <h2 className="mb-4 text-lg font-semibold text-fg">프로젝트 등록</h2>
-        <ProjectForm />
-      </section>
+      {/* 프로젝트 백오피스 진입 */}
+      <Link
+        href="/admin/projects"
+        className="card mt-4 flex items-center justify-between p-5 transition-colors hover:bg-surface-hover"
+      >
+        <div>
+          <h2 className="text-base font-semibold text-fg">프로젝트 관리</h2>
+          <p className="mt-1 text-sm text-muted">
+            프로젝트 등록·수정·삭제 · 총 {projects.length}개
+          </p>
+        </div>
+        <span className="text-accent">→</span>
+      </Link>
 
       {/* 접수된 문의 목록 */}
       <section className="mt-14">
         <h2 className="text-lg font-semibold text-fg">
-          문의 <span className="font-mono text-sm text-muted">({inquiries.length})</span>
+          문의 <span className="font-mono text-sm text-muted">({inquiries.length}
+          {pending > 0 && <span className="text-accent"> · 미완 {pending}</span>})</span>
         </h2>
         {inquiries.length === 0 ? (
           <p className="mt-3 text-sm text-muted">
@@ -73,6 +88,9 @@ export default async function AdminPage() {
                   </a>
                 )}
                 {q.message && <p className="mt-2 whitespace-pre-wrap text-sm text-muted">{q.message}</p>}
+                <div className="mt-3">
+                  <InquiryStatus id={q.id} status={q.status} />
+                </div>
               </li>
             ))}
           </ul>

--- a/app/admin/projects/[id]/edit/page.tsx
+++ b/app/admin/projects/[id]/edit/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import ProjectForm from "../../../../../components/admin/projectForm"
+import { getAdminProject } from "../../../../../lib/notion"
+import { blocksToText } from "../../../../../lib/notionWrite"
+
+export const metadata: Metadata = {
+  title: "프로젝트 수정",
+  robots: { index: false, follow: false },
+}
+export const dynamic = "force-dynamic"
+// 본문 블록 교체(다건 Notion 호출)가 기본 10초를 넘을 수 있어 상향.
+export const maxDuration = 60
+
+export default async function EditProject({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const project = await getAdminProject(id)
+  if (!project) notFound()
+
+  const initial = {
+    id: project.id,
+    name: project.name,
+    description: project.description,
+    tags: project.tags.join(", "),
+    github: project.github,
+    startDate: project.startDate,
+    endDate: project.endDate,
+    status: project.status,
+    impact: project.impact,
+    role: project.role,
+    teamSize: project.teamSize,
+    liveUrl: project.liveUrl,
+    group: project.group,
+    groupSummary: project.groupSummary,
+    cover: project.cover,
+    body: blocksToText(project.body || []),
+  }
+
+  return (
+    <main className="mx-auto max-w-[720px] px-6 py-16">
+      <Link href="/admin/projects" className="font-mono text-xs text-muted hover:text-accent">
+        ← 프로젝트
+      </Link>
+      <h1 className="mb-8 mt-4 text-2xl font-semibold text-fg">프로젝트 수정</h1>
+      <ProjectForm initial={initial} />
+    </main>
+  )
+}

--- a/app/admin/projects/new/page.tsx
+++ b/app/admin/projects/new/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import ProjectForm from "../../../../components/admin/projectForm"
+
+export const metadata: Metadata = {
+  title: "새 프로젝트",
+  robots: { index: false, follow: false },
+}
+export const dynamic = "force-dynamic"
+export const maxDuration = 60
+
+export default function NewProject() {
+  return (
+    <main className="mx-auto max-w-[720px] px-6 py-16">
+      <Link href="/admin/projects" className="font-mono text-xs text-muted hover:text-accent">
+        ← 프로젝트
+      </Link>
+      <h1 className="mb-8 mt-4 text-2xl font-semibold text-fg">새 프로젝트</h1>
+      <ProjectForm />
+    </main>
+  )
+}

--- a/app/admin/projects/page.tsx
+++ b/app/admin/projects/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { getAdminProjects } from "../../../lib/notion"
+import ProjectRowActions from "../../../components/admin/projectRowActions"
+
+export const metadata: Metadata = {
+  title: "프로젝트 관리",
+  robots: { index: false, follow: false },
+}
+export const dynamic = "force-dynamic"
+
+export default async function AdminProjects() {
+  const projects = await getAdminProjects()
+
+  return (
+    <main className="mx-auto max-w-[820px] px-6 py-16">
+      <Link href="/admin" className="font-mono text-xs text-muted hover:text-accent">
+        ← Admin
+      </Link>
+
+      <div className="mt-4 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-fg">
+          프로젝트 <span className="font-mono text-sm text-muted">({projects.length})</span>
+        </h1>
+        <Link
+          href="/admin/projects/new"
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
+        >
+          + 새 프로젝트
+        </Link>
+      </div>
+
+      {projects.length === 0 ? (
+        <p className="mt-8 text-sm text-muted">
+          아직 프로젝트가 없습니다. (NOTION_DB 미설정 시에도 비어 있음) — “+ 새 프로젝트”로 등록하세요.
+        </p>
+      ) : (
+        <ul className="mt-6 divide-y divide-line">
+          {projects.map((p) => (
+            <li key={p.id} className="py-5">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Link
+                    href={`/admin/projects/${p.id}/edit`}
+                    className="text-base font-semibold text-fg hover:text-accent"
+                  >
+                    {p.name}
+                  </Link>
+                  {p.status && (
+                    <span className="rounded-sm border border-line px-1.5 py-0.5 font-mono text-[10px] uppercase text-muted">
+                      {p.status}
+                    </span>
+                  )}
+                </div>
+                <time className="shrink-0 font-mono text-xs text-muted">{p.startDate || "—"}</time>
+              </div>
+              {p.description && (
+                <p className="mt-1.5 text-sm leading-relaxed text-muted line-clamp-2">{p.description}</p>
+              )}
+              <div className="mt-2.5 flex items-center justify-between gap-4">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
+                  {p.group && <span className="font-mono">{p.group}</span>}
+                  {p.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5">
+                      {p.tags.map((t) => (
+                        <span key={t} className="chip">{t}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <ProjectRowActions id={p.id} name={p.name} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/components/admin/inquiryStatus.tsx
+++ b/components/admin/inquiryStatus.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { updateInquiryStatus } from "../../app/admin/actions"
+import { useToast } from "./toast"
+
+// lib/inquiries.ts 의 INQUIRY_STATUSES 와 동기화(서버 전용 모듈을 클라이언트에 번들하지 않기 위해 상수만 복제).
+const STATUSES = ["신규", "처리중", "완료"] as const
+
+export default function InquiryStatus({ id, status }: { id: string; status: string }) {
+  const router = useRouter()
+  const { show, node } = useToast()
+  const [busy, setBusy] = useState(false)
+  const current = STATUSES.includes(status as (typeof STATUSES)[number]) ? status : STATUSES[0]
+
+  async function change(next: string) {
+    if (busy || next === current) return
+    setBusy(true)
+    try {
+      await updateInquiryStatus(id, next)
+      show("success", `상태를 “${next}”(으)로 변경했습니다.`)
+      router.refresh()
+    } catch (e) {
+      show("error", (e as Error).message || "상태 변경에 실패했습니다.")
+    }
+    setBusy(false)
+  }
+
+  return (
+    <div className="flex items-center gap-1" role="group" aria-label="문의 처리 상태">
+      {STATUSES.map((s) => {
+        const active = s === current
+        return (
+          <button
+            key={s}
+            type="button"
+            disabled={busy}
+            aria-pressed={active}
+            onClick={() => change(s)}
+            className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors disabled:opacity-50 ${
+              active
+                ? "border-accent bg-accent/10 text-accent"
+                : "border-line text-muted hover:border-accent hover:text-accent"
+            }`}
+          >
+            {s}
+          </button>
+        )
+      })}
+      {node}
+    </div>
+  )
+}

--- a/components/admin/projectForm.tsx
+++ b/components/admin/projectForm.tsx
@@ -1,40 +1,141 @@
 "use client"
 
-import { useActionState } from "react"
-import { submitProject } from "../../app/admin/actions"
-import { Field, Status, fieldCls, labelCls } from "./formFields"
-import type { ActionState } from "../../lib/adminForm"
+import { useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { saveProject } from "../../app/admin/actions"
+import { Field, fieldCls, labelCls } from "./formFields"
+import { useToast } from "./toast"
 
-const INIT: ActionState = { ok: false, message: "" }
+export interface ProjectFormInitial {
+  id?: string
+  name?: string
+  description?: string
+  tags?: string
+  github?: string
+  startDate?: string
+  endDate?: string
+  status?: string
+  impact?: string
+  role?: string
+  teamSize?: string
+  liveUrl?: string
+  group?: string
+  groupSummary?: string
+  cover?: string
+  body?: string
+}
 
-export default function ProjectForm() {
-  const [state, action, pending] = useActionState(submitProject, INIT)
+export default function ProjectForm({ initial = {} }: { initial?: ProjectFormInitial }) {
+  const isEdit = Boolean(initial.id)
+  const router = useRouter()
+  const { show, node } = useToast()
+  const [saving, setSaving] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (saving) return
+    const formData = new FormData(e.currentTarget)
+    setSaving(true)
+    try {
+      const res = await saveProject(formData)
+      if (res.ok) {
+        show("success", res.message)
+        router.push("/admin/projects")
+        router.refresh()
+        return // saving 유지(폼 언마운트)
+      }
+      show("error", res.message || "저장에 실패했습니다.")
+    } catch {
+      show(
+        "error",
+        "저장에 실패했습니다. 시간 초과 또는 네트워크 오류일 수 있어요. 잠시 후 다시 시도해주세요."
+      )
+    }
+    setSaving(false)
+  }
+
   return (
-    <form action={action} className="grid gap-4">
-      <Field label="프로젝트명" name="name" placeholder="프로젝트 이름" required />
-      <label className="block">
-        <span className={labelCls}>설명</span>
-        <textarea name="description" rows={3} className={fieldCls} placeholder="한두 문장 요약" />
-      </label>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Field label="태그 (쉼표로 구분)" name="tags" placeholder="C#, Azure" />
-        <Field label="GitHub / 링크" name="github" placeholder="https://github.com/…" />
-      </div>
-      <div className="grid gap-4 sm:grid-cols-3">
-        <Field label="시작일" name="startDate" type="date" />
-        <Field label="종료일" name="endDate" type="date" />
-        <Field label="상태 (status 옵션명)" name="status" placeholder="Done" />
-      </div>
-      <div>
-        <button
-          type="submit"
-          disabled={pending}
-          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
-        >
-          {pending ? "등록 중…" : "프로젝트 등록"}
-        </button>
-      </div>
-      <Status state={state} />
-    </form>
+    <div className="relative">
+      <form onSubmit={handleSubmit} className="grid gap-4">
+        {isEdit && <input type="hidden" name="id" value={initial.id} />}
+        {isEdit && <input type="hidden" name="originalBody" value={initial.body ?? ""} />}
+
+        <Field label="프로젝트명(경험)" name="name" placeholder="예: 멀티플랫폼 메시징 백엔드" required defaultValue={initial.name} />
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="대분류 그룹 (group)" name="group" placeholder="예: Omni 메시징 백엔드 (비우면 단독 프로젝트)" defaultValue={initial.group} />
+          <Field label="라이브 URL" name="liveUrl" placeholder="https://…" defaultValue={initial.liveUrl} />
+        </div>
+
+        <label className="block">
+          <span className={labelCls}>설명 (목록 카드 요약)</span>
+          <textarea name="description" rows={2} className={fieldCls} placeholder="한두 문장 요약" defaultValue={initial.description} />
+        </label>
+
+        <label className="block">
+          <span className={labelCls}>그룹 요약 (groupSummary · 대분류 상세 상단)</span>
+          <textarea name="groupSummary" rows={2} className={fieldCls} placeholder="같은 그룹의 여러 경험을 아우르는 요약" defaultValue={initial.groupSummary} />
+        </label>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="역할 (role)" name="role" placeholder="예: 백엔드 오너십" defaultValue={initial.role} />
+          <Field label="팀 규모 (teamSize)" name="teamSize" placeholder="예: 4명" defaultValue={initial.teamSize} />
+        </div>
+
+        <label className="block">
+          <span className={labelCls}>임팩트 (impact · 성과 지표)</span>
+          <textarea name="impact" rows={2} className={fieldCls} placeholder="예: p95 응답 320ms→90ms" defaultValue={initial.impact} />
+        </label>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="태그 (쉼표로 구분)" name="tags" placeholder="C#, .NET, Azure" defaultValue={initial.tags} />
+          <Field label="GitHub / 저장소" name="github" placeholder="https://github.com/…" defaultValue={initial.github} />
+        </div>
+
+        <Field label="커버 이미지 URL" name="cover" placeholder="https://… (비우면 해치 패턴 폴백)" defaultValue={initial.cover} />
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <Field label="시작일" name="startDate" type="date" defaultValue={initial.startDate} />
+          <Field label="종료일" name="endDate" type="date" defaultValue={initial.endDate} />
+          <Field label="상태 (status 옵션명)" name="status" placeholder="Done / In progress" defaultValue={initial.status} />
+        </div>
+
+        <label className="block">
+          <span className={labelCls}>본문 (마크다운 유사: # 제목, ``` 코드, - 목록)</span>
+          <textarea
+            name="body"
+            rows={12}
+            className={`${fieldCls} font-mono`}
+            placeholder={"## 배경\n문단 내용...\n\n- 핵심 기여\n\n```\n코드\n```"}
+            defaultValue={initial.body}
+          />
+        </label>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-accent-hover disabled:opacity-50"
+          >
+            {saving ? "저장 중…" : isEdit ? "변경 저장" : "프로젝트 등록"}
+          </button>
+          <Link href="/admin/projects" className="link-underline text-sm text-muted">
+            취소
+          </Link>
+        </div>
+      </form>
+
+      {saving && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-page/70 backdrop-blur-[1px]">
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-line border-t-accent" />
+            저장 중…
+          </div>
+        </div>
+      )}
+
+      {node}
+    </div>
   )
 }

--- a/components/admin/projectRowActions.tsx
+++ b/components/admin/projectRowActions.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { deleteProject } from "../../app/admin/actions"
+import { useToast } from "./toast"
+
+export default function ProjectRowActions({ id, name }: { id: string; name: string }) {
+  const router = useRouter()
+  const { show, node } = useToast()
+  const [busy, setBusy] = useState(false)
+
+  async function remove() {
+    if (busy) return
+    if (!confirm(`“${name}”을(를) 삭제(아카이브)할까요? Notion 휴지통에서 복구할 수 있습니다.`)) return
+    setBusy(true)
+    try {
+      await deleteProject(id)
+      show("success", "삭제(아카이브)했습니다.")
+      router.refresh()
+    } catch {
+      show("error", "삭제에 실패했습니다. 잠시 후 다시 시도해주세요.")
+    }
+    setBusy(false)
+  }
+
+  return (
+    <div className="flex items-center gap-3 text-xs">
+      <Link href={`/admin/projects/${id}/edit`} className="link-underline text-muted hover:text-accent">
+        수정
+      </Link>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={remove}
+        className="link-underline text-muted hover:text-red-500 disabled:opacity-50"
+      >
+        삭제
+      </button>
+      {node}
+    </div>
+  )
+}

--- a/lib/inquiries.ts
+++ b/lib/inquiries.ts
@@ -10,11 +10,17 @@ export const INQUIRY_PROPS = {
   email: "Email",
   type: "Type",
   message: "Message",
+  status: "Status",
 } as const
 
 // 문의 유형 (select 옵션명)
 export const INQUIRY_TYPES = ["이메일 요청", "면접 요청"] as const
 export type InquiryType = (typeof INQUIRY_TYPES)[number]
+
+// 문의 처리 상태 (Status 속성 옵션명). 배열 첫 항목이 기본값.
+export const INQUIRY_STATUSES = ["신규", "처리중", "완료"] as const
+export type InquiryStatus = (typeof INQUIRY_STATUSES)[number]
+export const DEFAULT_INQUIRY_STATUS: InquiryStatus = INQUIRY_STATUSES[0]
 
 function headers() {
   return {
@@ -68,6 +74,7 @@ export interface Inquiry {
   email: string
   type: string
   message: string
+  status: string
   createdTime: string
 }
 
@@ -103,17 +110,51 @@ export async function getInquiries(): Promise<Inquiry[]> {
 
     return (json.results || []).map((page) => {
       const p = (name: string) => page.properties?.[name] as Record<string, unknown> | undefined
+      // Status 는 사용자가 Select 또는 Notion Status 타입 중 무엇으로 만들었든 읽는다.
+      const statusProp = p(INQUIRY_PROPS.status)
+      const status =
+        (statusProp?.select as { name?: string } | undefined)?.name ??
+        (statusProp?.status as { name?: string } | undefined)?.name ??
+        DEFAULT_INQUIRY_STATUS
       return {
         id: page.id,
         name: plain(p(INQUIRY_PROPS.name)?.title as NotionRichText[] | undefined),
         email: (p(INQUIRY_PROPS.email)?.email as string) ?? "",
         type: ((p(INQUIRY_PROPS.type)?.select as { name?: string } | undefined)?.name) ?? "",
         message: plain(p(INQUIRY_PROPS.message)?.rich_text as NotionRichText[] | undefined),
+        status,
         createdTime: page.created_time ?? "",
       }
     })
   } catch (e) {
     console.error("[inquiries] Notion fetch failed:", (e as Error).message)
     return []
+  }
+}
+
+async function patchStatus(id: string, value: Record<string, unknown>) {
+  return fetch(`${NOTION_API}/pages/${id}`, {
+    method: "PATCH",
+    headers: headers(),
+    body: JSON.stringify({ properties: { [INQUIRY_PROPS.status]: value } }),
+  })
+}
+
+// 문의 처리 상태 변경. Status 속성이 Select 든 Notion Status 타입이든 동작하도록
+// select 로 먼저 시도하고, 실패 시 status 타입으로 재시도한다.
+// Status 속성이 아예 없으면(오너 미설정) Notion 이 400 을 주고, 그 메시지를 그대로 던진다.
+export async function setInquiryStatus(id: string, status: string): Promise<void> {
+  if (!TOKEN) throw new Error("NOTION_TOKEN 미설정")
+
+  let res = await patchStatus(id, { select: { name: status } })
+  if (!res.ok) {
+    // Select 가 아니면(예: Notion Status 타입) status 형태로 한 번 더 시도.
+    res = await patchStatus(id, { status: { name: status } })
+  }
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "")
+    throw new Error(
+      `문의 상태 변경 실패 (${res.status}). Inquiries DB 에 "${INQUIRY_PROPS.status}" 속성(옵션: ${INQUIRY_STATUSES.join("/")})이 있는지 확인하세요. ${detail.slice(0, 200)}`
+    )
   }
 }

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -3,7 +3,9 @@ import type {
   ProjectGroup,
   ProjectTag,
 } from "../components/projects/projectItem"
+import type { Block } from "./posts"
 import { TOKEN, DATABASE_ID } from "../config"
+import { PROJECT_PROPS } from "./notionWrite"
 import { fallbackExperiences } from "./projectsFallback"
 import { fetchBody } from "./postsData"
 
@@ -198,4 +200,89 @@ export async function getProjectGroup(
     })
   )
   return group
+}
+
+// ── 관리자(백오피스) 전용 조회 ────────────────────────────────────
+// 공개 조회(그룹핑·boolean status)와 달리, 수정 폼 프리필용으로 각 경험(행)을
+// pageId·원본 문자열 값(status 옵션명·커버 URL 등)째로 반환하고 캐시를 우회한다.
+export interface AdminProject {
+  id: string
+  name: string
+  description: string
+  tags: string[]
+  github: string
+  startDate: string
+  endDate: string
+  status: string // status 옵션명 원본(예: "Done"/"In progress")
+  impact: string
+  role: string
+  teamSize: string
+  liveUrl: string
+  group: string
+  groupSummary: string
+  cover: string
+  body?: Block[]
+}
+
+function mapAdminProject(page: NotionPage): AdminProject {
+  const p = page.properties || {}
+  return {
+    id: page.id,
+    name: p.projectName?.title?.[0]?.plain_text ?? "",
+    description: p.description?.rich_text?.[0]?.plain_text ?? "",
+    tags: (p.tag?.multi_select ?? []).map((t) => t.name).filter(Boolean),
+    github: p.github?.url || "",
+    startDate: p.workPeriod?.date?.start || "",
+    endDate: p.workPeriod?.date?.end || "",
+    status: p.status?.status?.name ?? "",
+    impact: p.impact?.rich_text?.[0]?.plain_text ?? "",
+    role: p.role?.rich_text?.[0]?.plain_text ?? "",
+    teamSize: p.teamSize?.rich_text?.[0]?.plain_text ?? "",
+    liveUrl: p.liveUrl?.url || "",
+    group: p.group?.select?.name ?? "",
+    groupSummary: p.groupSummary?.rich_text?.[0]?.plain_text ?? "",
+    cover: page.cover?.external?.url || page.cover?.file?.url || "",
+  }
+}
+
+// 백오피스 목록: 라이브 Notion 행 전체(캐시 우회). 미설정·실패 시 빈 목록.
+// (fallback 은 반환하지 않는다 — 관리 대상은 실제 DB 행뿐이라야 하므로.)
+export async function getAdminProjects(): Promise<AdminProject[]> {
+  if (!TOKEN || !DATABASE_ID) return []
+  try {
+    const res = await fetch(`https://api.notion.com/v1/databases/${DATABASE_ID}/query`, {
+      method: "POST",
+      headers: notionHeaders(),
+      body: JSON.stringify({
+        sorts: [{ property: PROJECT_PROPS.name, direction: "ascending" }],
+        page_size: 100,
+      }),
+      cache: "no-store",
+    })
+    if (!res.ok) throw new Error(`Notion API ${res.status}`)
+    const data = (await res.json()) as NotionQueryResponse
+    return (data.results || []).map(mapAdminProject).filter((p) => p.name)
+  } catch (e) {
+    console.error("[admin projects] Notion fetch failed:", (e as Error).message)
+    return []
+  }
+}
+
+// 수정 폼 프리필용 단건(본문 포함, 최신값).
+export async function getAdminProject(id: string): Promise<AdminProject | null> {
+  if (!TOKEN || !DATABASE_ID) return null
+  try {
+    const res = await fetch(`https://api.notion.com/v1/pages/${id}`, {
+      headers: notionHeaders(),
+      cache: "no-store",
+    })
+    if (!res.ok) throw new Error(`Notion page ${res.status}`)
+    const page = (await res.json()) as NotionPage
+    const meta = mapAdminProject(page)
+    meta.body = await fetchBody(id, true)
+    return meta
+  } catch (e) {
+    console.error("[admin project] Notion fetch failed:", (e as Error).message)
+    return null
+  }
 }

--- a/lib/notionWrite.ts
+++ b/lib/notionWrite.ts
@@ -16,6 +16,12 @@ export const PROJECT_PROPS = {
   github: "github",
   workPeriod: "workPeriod",
   status: "status",
+  impact: "impact",
+  role: "role",
+  teamSize: "teamSize",
+  liveUrl: "liveUrl",
+  group: "group",
+  groupSummary: "groupSummary",
 } as const
 
 function headers() {
@@ -271,22 +277,79 @@ export interface ProjectInput {
   startDate: string
   endDate: string
   status: string
+  // 케이스스터디/대분류 필드 (Notion projects DB 에 이미 존재하는 속성)
+  impact: string
+  role: string
+  teamSize: string
+  liveUrl: string
+  group: string
+  groupSummary: string
+  // 페이지 커버 이미지 URL(외부). 상세 히어로·목록 카드에 노출.
+  cover: string
+  // 상세 본문(마크다운 유사 텍스트).
+  body: string
+}
+
+// 생성/수정 공용 속성 빌더.
+// 수정 시엔 빈 값을 null 로 클리어(생성 시엔 빈 값은 넣지 않아도 동일 효과지만
+// 일관성·명확성을 위해 동일 규칙 적용).
+function projectProperties(input: ProjectInput): Record<string, unknown> {
+  const properties: Record<string, unknown> = {
+    [PROJECT_PROPS.name]: { title: rich(input.name) },
+    [PROJECT_PROPS.description]: { rich_text: rich(input.description) },
+    [PROJECT_PROPS.tags]: { multi_select: input.tags.map((name) => ({ name })) },
+    [PROJECT_PROPS.impact]: { rich_text: rich(input.impact) },
+    [PROJECT_PROPS.role]: { rich_text: rich(input.role) },
+    [PROJECT_PROPS.teamSize]: { rich_text: rich(input.teamSize) },
+    [PROJECT_PROPS.groupSummary]: { rich_text: rich(input.groupSummary) },
+  }
+  properties[PROJECT_PROPS.github] = input.github ? { url: input.github } : { url: null }
+  properties[PROJECT_PROPS.liveUrl] = input.liveUrl ? { url: input.liveUrl } : { url: null }
+  properties[PROJECT_PROPS.workPeriod] = input.startDate
+    ? { date: { start: input.startDate, end: input.endDate || null } }
+    : { date: null }
+  properties[PROJECT_PROPS.status] = input.status
+    ? { status: { name: input.status } }
+    : { status: null }
+  properties[PROJECT_PROPS.group] = input.group
+    ? { select: { name: input.group } }
+    : { select: null }
+  return properties
 }
 
 export async function createProjectPage(input: ProjectInput): Promise<{ id: string }> {
   if (!TOKEN || !DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_DB 미설정")
 
-  const properties: Record<string, unknown> = {
-    [PROJECT_PROPS.name]: { title: rich(input.name) },
-    [PROJECT_PROPS.description]: { rich_text: rich(input.description) },
-    [PROJECT_PROPS.tags]: { multi_select: input.tags.map((name) => ({ name })) },
+  const page: Record<string, unknown> = {
+    parent: { database_id: DATABASE_ID },
+    properties: projectProperties(input),
   }
-  if (input.github) properties[PROJECT_PROPS.github] = { url: input.github }
-  if (input.startDate)
-    properties[PROJECT_PROPS.workPeriod] = {
-      date: { start: input.startDate, end: input.endDate || null },
-    }
-  if (input.status) properties[PROJECT_PROPS.status] = { status: { name: input.status } }
+  if (input.cover) page.cover = { type: "external", external: { url: input.cover } }
 
-  return createPage({ parent: { database_id: DATABASE_ID }, properties })
+  const created = await createPage(page)
+  await appendChildren(created.id, textToBlocks(input.body))
+  return created
+}
+
+// replaceBodyContent=false 면 속성만 갱신하고 본문 블록 교체를 건너뛴다(빠른 저장).
+export async function updateProjectPage(
+  id: string,
+  input: ProjectInput,
+  replaceBodyContent = true
+): Promise<{ id: string }> {
+  if (!TOKEN || !DATABASE_ID) throw new Error("NOTION_TOKEN / NOTION_DB 미설정")
+
+  const body: Record<string, unknown> = { properties: projectProperties(input) }
+  // 커버: URL 이 있으면 설정, 비우면 제거(null).
+  body.cover = input.cover ? { type: "external", external: { url: input.cover } } : null
+
+  await patchPage(id, body)
+  if (replaceBodyContent) await replaceBody(id, input.body)
+  return { id }
+}
+
+// 삭제 = 아카이브(Notion 휴지통에서 복구 가능).
+export async function archiveProjectPage(id: string): Promise<void> {
+  if (!TOKEN) throw new Error("NOTION_TOKEN 미설정")
+  await patchPage(id, { archived: true })
 }


### PR DESCRIPTION
## What (#84)
백오피스(admin)에 **프로젝트 CRUD**와 **문의 처리 상태**를 추가합니다. 블로그 백오피스와 동일한 패턴(목록/new/edit·서버 액션·토스트·아카이브)을 미러링했습니다.

### 프로젝트 CRUD
- **목록** `/admin/projects` — 프로젝트(경험) 행 목록, 그룹·상태·태그 표시, 수정/삭제
- **등록/수정** `/admin/projects/new`, `/admin/projects/[id]/edit` — 생성/수정 겸용 폼
- 편집 필드: 프로젝트명, 대분류 group, 설명, groupSummary, role, teamSize, impact, 태그, github, **커버 이미지 URL**, liveUrl, 기간, status, **본문(마크다운)**
- 저장 시 `/projects`(layout)·`/` 재검증 → 사이트 즉시 반영
- 삭제 = Notion 아카이브(휴지통 복구 가능)
- admin 홈: 인라인 등록 폼 → "프로젝트 관리" 카드로 교체(블로그와 대칭)

### 문의 처리 상태
- 문의별 **신규 / 처리중 / 완료** 상태 칩·변경 버튼, admin 홈에 "미완" 카운트
- `Status` 속성을 **Select·Notion Status 타입 모두** 대응해 읽고, 변경 시 select→status 순으로 시도

## 데이터 계층
- `lib/notionWrite.ts` — `ProjectInput` 확장, `projectProperties` 빌더, `updateProjectPage`/`archiveProjectPage`
- `lib/notion.ts` — 관리자용 `getAdminProjects()`/`getAdminProject()` (초안 포함·캐시 우회·본문/커버/status 원본)
- `lib/inquiries.ts` — `Status` 읽기 + `setInquiryStatus`
- `app/admin/actions.ts` — `saveProject`·`deleteProject`·`updateInquiryStatus`

## ⚠️ 오너 설정 (Notion 스키마)
- **문의 상태**를 쓰려면 Inquiries DB에 **`Status` 속성**(Select 권장, 옵션 `신규`/`처리중`/`완료`)을 추가해야 합니다. 없으면 목록에선 "신규"로 표시되고, 변경 시도 시 안내 에러가 납니다(앱은 정상 동작).
- 프로젝트의 impact·role·teamSize·liveUrl·group·groupSummary 속성은 projects DB에 **이미 존재**하므로 별도 설정 불필요.

## #85 (콘텐츠/설정 채우기) 연관
이 PR로 **커버 이미지·impact·role·teamSize·group을 admin UI에서 입력**할 수 있게 되어 #85의 콘텐츠 입력 경로가 열립니다. 다만 #85의 나머지는 코드가 아닌 **오너 직접 작업**이라 이 PR로 닫지 않습니다:
- [ ] 각 프로젝트 실제 커버 이미지·impact 수치 입력 (이제 admin에서 가능)
- [ ] Vercel 환경변수 `RESEND_API_KEY`·`CONTACT_NOTIFY_EMAIL` 설정 (대시보드)

## Verification
- `next lint` → 경고/에러 없음
- `next build` → 성공 (16개 정적 페이지 + `/admin/projects*` 동적 라우트)
- ⚠️ Notion 쓰기 경로는 실제 토큰/DB 필요 → Vercel 프리뷰(또는 실 DB)에서 등록/수정/상태변경 수동 확인 권장

Closes #84
Refs #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)