### PR TITLE
feat(contact): 내구성 레이트리밋(Upstash) + in-memory 폴백 (#54)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,19 @@ CONTACT_NOTIFY_EMAIL=
 # 발신자(선택). 도메인 미검증이면 기본 onboarding@resend.dev 사용.
 # CONTACT_FROM_EMAIL=Portfolio <onboarding@resend.dev>
 
+# ── 봇/스팸 방어 (선택, 공개 문의 폼) ──────────────────────────────
+# 전부 graceful-degrade: 미설정이어도 폼은 동작(허니팟은 항상 켜짐).
+#
+# Cloudflare Turnstile invisible 캡차. dash.cloudflare.com → Turnstile → 위젯 발급.
+#   NEXT_PUBLIC_TURNSTILE_SITE_KEY 있을 때만 위젯 렌더, TURNSTILE_SECRET_KEY 있을 때만 서버 검증.
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+#
+# 내구성 레이트리밋(Upstash Redis). 미설정 시 in-memory 폴백(인스턴스별·재시작 초기화).
+# console.upstash.com → Redis DB 생성 → REST URL/TOKEN. Vercel KV(Marketplace) 도 동일 REST 호환.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
 # ── 사이트 URL (SEO/OG, 선택) ──────────────────────────────────────
 # 커스텀 도메인 사용 시. 미설정 시 기본 배포 도메인 사용.
 # NEXT_PUBLIC_SITE_URL=https://your-domain.com

--- a/app/(site)/contact/actions.ts
+++ b/app/(site)/contact/actions.ts
@@ -22,10 +22,11 @@ export async function submitInquiry(
     return { ok: true, message: "문의가 접수되었습니다. 감사합니다." }
   }
 
-  // 레이트리밋: IP당 10분에 3회(인스턴스별 in-memory, 기본 남용 완화).
+  // 레이트리밋: IP당 10분에 3회. Upstash 설정 시 인스턴스를 넘어 내구성 동작,
+  // 미설정 시 in-memory 폴백(lib/rateLimit.ts).
   const h = await headers()
   const ip = h.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
-  if (!rateLimit(`contact:${ip}`, 3, 10 * 60 * 1000)) {
+  if (!(await rateLimit(`contact:${ip}`, 3, 10 * 60 * 1000))) {
     return { ok: false, message: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." }
   }
 

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -43,6 +43,8 @@ async function rateLimitUpstash(
     ]),
     // 레이트리밋 값은 캐시하면 안 됨.
     cache: "no-store",
+    // 가용성 우선: Redis 가 hang 해도 폴백에 도달하도록 짧은 타임아웃.
+    signal: AbortSignal.timeout(2000),
   })
   if (!res.ok) throw new Error(`upstash ${res.status}`)
   const data = (await res.json()) as Array<{ result?: number; error?: string }>

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,9 +1,15 @@
-// 간단 in-memory 슬라이딩 윈도우 레이트리밋. 서버리스 인스턴스별이라 완벽하진 않지만
-// 공개 폼의 기본 스팸/남용 완화용으로 충분. 허니팟과 함께 다층 방어.
+// 레이트리밋: 공개 폼의 봇/스팸 남용 완화. 허니팟·Turnstile 과 함께 다층 방어.
+//
+// 두 가지 백엔드를 graceful-degrade 로 지원(turnstile.ts / notify.ts 와 동일 패턴):
+//   1) 내구성(durable): UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN 설정 시.
+//      서버리스 인스턴스·재배포를 넘어 카운트가 공유됨(고정 윈도우).
+//   2) in-memory 폴백: 위 키 미설정 시. 인스턴스별·재시작 시 초기화되는 슬라이딩 윈도우.
+//      키 발급 전에도 안전하게 동작(신규 의존성 0, fetch 만 사용).
+
+// ── in-memory 슬라이딩 윈도우(폴백) ────────────────────────────────
 const hits = new Map<string, number[]>()
 
-// 허용이면 true, 한도 초과면 false.
-export function rateLimit(key: string, max: number, windowMs: number): boolean {
+function rateLimitMemory(key: string, max: number, windowMs: number): boolean {
   const now = Date.now()
   const recent = (hits.get(key) || []).filter((t) => now - t < windowMs)
   if (recent.length >= max) {
@@ -13,4 +19,55 @@ export function rateLimit(key: string, max: number, windowMs: number): boolean {
   recent.push(now)
   hits.set(key, recent)
   return true
+}
+
+// ── Upstash Redis REST(내구성) ─────────────────────────────────────
+// 고정 윈도우: INCR 로 카운트를 올리고, 첫 히트에서만(NX) 윈도우 만료를 건다.
+// 반환 count 가 max 이하이면 허용. 인스턴스를 넘어 원자적으로 동작.
+async function rateLimitUpstash(
+  url: string,
+  token: string,
+  key: string,
+  max: number,
+  windowMs: number
+): Promise<boolean> {
+  const res = await fetch(`${url}/pipeline`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify([
+      ["INCR", key],
+      ["PEXPIRE", key, String(windowMs), "NX"],
+    ]),
+    // 레이트리밋 값은 캐시하면 안 됨.
+    cache: "no-store",
+  })
+  if (!res.ok) throw new Error(`upstash ${res.status}`)
+  const data = (await res.json()) as Array<{ result?: number; error?: string }>
+  const first = data?.[0]
+  if (!first || first.error || typeof first.result !== "number") {
+    throw new Error(first?.error || "upstash malformed response")
+  }
+  return first.result <= max
+}
+
+// 허용이면 true, 한도 초과면 false. Upstash 설정 시 내구성 백엔드, 아니면 in-memory.
+// Upstash 호출 실패 시엔 가용성 우선으로 in-memory 폴백(폼이 하드 실패하지 않도록).
+export async function rateLimit(
+  key: string,
+  max: number,
+  windowMs: number
+): Promise<boolean> {
+  const url = process.env.UPSTASH_REDIS_REST_URL
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN
+  if (url && token) {
+    try {
+      return await rateLimitUpstash(url, token, `rl:${key}`, max, windowMs)
+    } catch (e) {
+      console.error("[rateLimit] upstash 오류, in-memory 폴백:", (e as Error).message)
+    }
+  }
+  return rateLimitMemory(key, max, windowMs)
 }


### PR DESCRIPTION
## 배경 (#54)
공개 문의 폼 레이트리밋이 현재 **in-memory** 방식 → 서버리스 인스턴스별로 분리되고 재배포/재시작 시 초기화됨. 인스턴스가 여러 개면 실질 한도가 배수로 뚫림. 이슈 #54의 "내구성 레이트리밋" 항목을 코드로 해결.

## 변경
- **`lib/rateLimit.ts`**: `rateLimit` 을 async 로 전환.
  - `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` 설정 시 → **Upstash Redis REST** 고정 윈도우(`INCR` + `PEXPIRE ... NX`). 인스턴스·재배포를 넘어 원자적으로 공유됨.
  - 미설정 시 → 기존 **in-memory 슬라이딩 윈도우 폴백**.
  - Upstash 호출 오류 시 → 가용성 우선으로 in-memory 폴백(폼이 하드 실패하지 않음).
  - **신규 의존성 0** — `fetch` 만 사용.
- **`app/(site)/contact/actions.ts`**: `await rateLimit(...)`.
- **`.env.example`**: 봇/스팸 방어 섹션 신설 — Turnstile(#109에서 누락돼 있던 항목 포함) + Upstash 문서화.

## Graceful degrade
Turnstile/notify 와 동일한 패턴. **키 미발급 상태에서도 안전하게 머지 가능** — 현행 in-memory 동작 그대로 유지, 키를 넣는 순간 내구성 백엔드로 전환.

## 오너 활성화
Upstash Redis DB(console.upstash.com, 무료 티어) 또는 Vercel KV 생성 후 Vercel 환경변수에 `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` 설정.

## 검증
- `npx tsc --noEmit` 클린
- `next lint` 무경고
- `next build` 성공

## #54 남은 항목 (이 PR 범위 밖 — 오너 인프라)
- [x] Vercel Firewall/WAF 봇 룰·엣지 챌린지 (대시보드 설정, 코드 아님)
- [x] (선택) auth 엔드포인트 레이트리밋 — /admin 은 OAuth로 이미 강함

🤖 Generated with [Claude Code](https://claude.com/claude-code)