### PR TITLE
feat(auth): /api/auth 엔드포인트 레이트리밋 (#54)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,36 @@
-// /admin/* 요청을 가로채 인증(authorized 콜백)을 강제한다.
-// 미인증 접근은 NextAuth 기본 로그인 페이지로 리다이렉트된다.
-export { auth as middleware } from "@/auth"
+// 미들웨어 2역할:
+//  1) /api/auth/* (로그인·콜백·세션) 레이트리밋 — auth 엔드포인트 남용/무차별 완화.
+//     Upstash 설정 시 내구성, 미설정 시 in-memory 폴백(lib/rateLimit.ts).
+//  2) /admin/* 인증 강제 — 미인증 접근은 NextAuth 로그인 페이지로 리다이렉트.
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import { rateLimit } from "@/lib/rateLimit"
+
+export default auth(async (req) => {
+  const { pathname } = req.nextUrl
+
+  // 1) auth 엔드포인트 레이트리밋: IP당 1분 20회. OAuth 플로우(리다이렉트·콜백·세션
+  //    폴링)는 정상 사용 시 이 한도에 닿지 않음 → 남용 트래픽만 429 로 차단.
+  if (pathname.startsWith("/api/auth")) {
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
+    if (!(await rateLimit(`auth:${ip}`, 20, 60 * 1000))) {
+      return new NextResponse("Too Many Requests", { status: 429 })
+    }
+    return NextResponse.next()
+  }
+
+  // 2) /admin 보호: 미인증이면 로그인으로(원래 경로를 callbackUrl 로 보존).
+  if (pathname.startsWith("/admin") && !req.auth?.user) {
+    const url = req.nextUrl.clone()
+    url.pathname = "/api/auth/signin"
+    url.searchParams.set("callbackUrl", pathname)
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+})
 
 export const config = {
-  // 정적 파일/이미지/공개 auth 엔드포인트는 제외하고 /admin 이하만 검사.
-  matcher: ["/admin/:path*"],
+  // /admin 이하(인증) + /api/auth 이하(레이트리밋)만 검사. 정적 파일·이미지 제외.
+  matcher: ["/admin/:path*", "/api/auth/:path*"],
 }


### PR DESCRIPTION
## 배경 (#54)
`middleware.ts` 가 지금까지 `/admin/*` 인증 강제만 담당하고 **`/api/auth/*`(로그인·콜백·세션)은 무방비**였음. #54의 "(선택) auth 엔드포인트 레이트리밋" 항목을 코드로 처리.

## 변경
- **`middleware.ts`**: `auth()` 래퍼로 확장.
  - **`/api/auth/*` 레이트리밋** — IP당 1분 20회 초과 시 `429`. OAuth 정상 플로우(리다이렉트·콜백·세션 폴링)는 이 한도에 닿지 않고, 남용 트래픽만 차단.
  - **`/admin/*` 인증 보호 보존** — 미인증 시 `/api/auth/signin` 리다이렉트(`callbackUrl` 유지). 기존 동작과 동일.
  - `matcher` 에 `/api/auth/:path*` 추가.
- 레이트리밋은 **기존 `lib/rateLimit` 재사용** — Upstash 설정 시 내구성, 미설정 시 in-memory 폴백. 신규 의존성 0.

## 참고 — 값은 낮지만 defense-in-depth
관리자는 GitHub OAuth(단일 허용 계정)라 자격증명 무차별 대입 벡터 자체가 작음. 그래도 auth 엔드포인트 스팸/남용에 대한 엣지 앞단 완화 계층을 추가.

## 검증
- `npx tsc --noEmit` 클린
- `next lint` 무경고
- `next build` 성공 (Middleware 컴파일 OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)